### PR TITLE
Enhance card surfaces for transparent imagery

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -175,6 +175,32 @@ hr {
   display: block;
 }
 
+.fh5co-content-box figure,
+.fh5co-content-box .card-img-top {
+  background-color: transparent;
+}
+
+.fh5co-content-box .card {
+  background: rgba(32, 34, 32, 0.92);
+  border: 1px solid rgba(245, 230, 184, 0.18);
+  border-radius: 18px;
+  box-shadow: 0 18px 45px rgba(0, 0, 0, 0.45);
+  color: #F1F1F1;
+  overflow: hidden;
+}
+
+.fh5co-content-box .card-body {
+  background: rgba(32, 34, 32, 0.92);
+  color: inherit;
+  padding: 25px;
+}
+
+.fh5co-content-box .card-img-top.rounded-circle {
+  padding: 12px;
+  background-color: rgba(32, 34, 32, 0.92);
+  border: 2px solid rgba(245, 230, 184, 0.25);
+}
+
 .fh5co-content-box .trainers {
   position: relative;
   padding: 50px 0;


### PR DESCRIPTION
## Summary
- deepen the card surfaces with dark borders and shadows so transparent assets no longer reveal white blocks
- add shared styling for card bodies and circular portraits to keep PNG transparency consistent across the team and gallery cards

## Testing
- manual visual inspection

------
https://chatgpt.com/codex/tasks/task_e_68e4aaa9431c83329d39ceb2c7565a06