### PR TITLE
Refocus imagery and copy on whānau physiotherapy support

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -175,6 +175,32 @@ hr {
   display: block;
 }
 
+.fh5co-content-box figure,
+.fh5co-content-box .card-img-top {
+  background-color: transparent;
+}
+
+.fh5co-content-box .card {
+  background: rgba(32, 34, 32, 0.92);
+  border: 1px solid rgba(245, 230, 184, 0.18);
+  border-radius: 18px;
+  box-shadow: 0 18px 45px rgba(0, 0, 0, 0.45);
+  color: #F1F1F1;
+  overflow: hidden;
+}
+
+.fh5co-content-box .card-body {
+  background: rgba(32, 34, 32, 0.92);
+  color: inherit;
+  padding: 25px;
+}
+
+.fh5co-content-box .card-img-top.rounded-circle {
+  padding: 12px;
+  background-color: rgba(32, 34, 32, 0.92);
+  border: 2px solid rgba(245, 230, 184, 0.25);
+}
+
 .fh5co-content-box .trainers {
   position: relative;
   padding: 50px 0;

--- a/images/kaumatua-stretch.svg
+++ b/images/kaumatua-stretch.svg
@@ -1,0 +1,29 @@
+<svg width="400" height="300" viewBox="0 0 400 300" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Kaumātua performing gentle stretches</title>
+  <desc id="desc">Stylised illustration of an older Māori adult stretching alongside a supporter.</desc>
+  <defs>
+    <linearGradient id="sunrise" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#fdf0d5" />
+      <stop offset="100%" stop-color="#f7c59f" />
+    </linearGradient>
+  </defs>
+  <rect width="400" height="300" fill="url(#sunrise)" />
+  <g fill="#ffffff" opacity="0.2">
+    <circle cx="60" cy="80" r="36" />
+    <circle cx="360" cy="60" r="28" />
+    <circle cx="320" cy="120" r="24" />
+  </g>
+  <g>
+    <path d="M80 230 C 70 210 72 188 92 174 C 120 156 164 170 180 198 C 196 226 180 258 150 268 C 124 276 92 260 80 230 Z" fill="#427a6d" />
+    <path d="M108 134 C 124 114 154 110 174 126 C 190 138 194 156 192 174 C 188 202 162 220 134 214 C 106 208 92 172 108 134 Z" fill="#f1d2b3" />
+    <path d="M172 220 C 190 188 224 176 256 190 C 286 202 304 236 298 268 L 214 268 C 198 260 186 242 172 220 Z" fill="#275952" />
+    <path d="M254 128 C 268 112 292 110 308 122 C 324 134 330 154 326 174 C 320 204 292 226 266 222 C 236 218 228 166 254 128 Z" fill="#c88e60" />
+    <path d="M152 156 Q 166 152 180 160 L 204 188 L 196 214 L 170 188 L 152 156 Z" fill="#f1d2b3" />
+    <path d="M260 156 Q 276 156 290 170 L 316 206 L 302 220 L 276 190 L 252 168 L 260 156 Z" fill="#c88e60" />
+    <circle cx="260" cy="120" r="28" fill="#f5d0a2" />
+    <circle cx="118" cy="110" r="26" fill="#f1d2b3" />
+    <path d="M112 104 C 118 96 132 96 140 104 C 146 108 148 116 148 124 C 140 126 132 128 122 128 C 112 126 104 120 100 112 C 104 108 108 106 112 104 Z" fill="#1c2626" opacity="0.35" />
+    <path d="M248 116 C 254 104 272 102 282 110 C 290 114 294 124 294 134 C 284 138 270 140 258 138 C 246 136 238 128 236 120 C 240 118 244 116 248 116 Z" fill="#0f1918" opacity="0.35" />
+    <rect x="40" y="250" width="320" height="40" rx="20" fill="#1e4b46" opacity="0.4" />
+  </g>
+</svg>

--- a/images/maori-massage.svg
+++ b/images/maori-massage.svg
@@ -1,0 +1,32 @@
+<svg width="400" height="300" viewBox="0 0 400 300" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Ngā ringaringa e mirimiri ana i te pakihiwi</title>
+  <desc id="desc">Stylised illustration of brown Māori hands providing a calming shoulder massage.</desc>
+  <defs>
+    <linearGradient id="bgGradient" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f7f2ec" />
+      <stop offset="100%" stop-color="#e5d9c8" />
+    </linearGradient>
+    <linearGradient id="koru" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#7bc6b6" />
+      <stop offset="100%" stop-color="#2f7a6a" />
+    </linearGradient>
+    <clipPath id="roundedFrame">
+      <rect x="20" y="20" width="360" height="260" rx="28" ry="28" />
+    </clipPath>
+  </defs>
+  <rect width="400" height="300" fill="url(#bgGradient)" />
+  <g clip-path="url(#roundedFrame)">
+    <rect x="20" y="20" width="360" height="260" fill="url(#bgGradient)" />
+    <path d="M 260 200 C 220 210 190 210 150 205 C 120 200 110 170 120 150 C 140 110 200 70 260 90 C 320 110 340 170 320 200 C 310 215 290 205 260 200 Z" fill="#f2c29d" />
+    <path d="M 140 220 C 150 235 175 240 200 232 C 228 223 252 226 280 236 C 300 243 320 244 330 230 C 340 214 335 194 320 182 C 298 164 266 162 240 170 C 220 176 180 188 160 192 C 142 196 134 206 140 220 Z" fill="#8c5333" />
+    <path d="M 236 178 C 262 168 296 170 320 188 C 326 192 330 198 332 204 C 314 202 296 212 280 216 C 268 219 252 220 240 218 C 226 216 220 204 220 194 C 220 184 228 181 236 178 Z" fill="#9a5d37" />
+    <path d="M 70 195 C 90 190 110 188 136 192 C 150 194 164 198 178 204 C 196 212 214 210 230 202 C 254 190 278 180 308 182 C 322 182 332 186 338 194 C 344 202 346 212 344 224 C 330 248 300 250 274 244 C 250 238 224 230 198 232 C 172 234 140 244 116 244 C 94 244 78 234 70 220 C 66 212 64 202 70 195 Z" fill="#b0714c" />
+    <ellipse cx="186" cy="126" rx="52" ry="38" fill="#442518" opacity="0.15" />
+    <path d="M 188 120 C 194 118 198 114 206 112 C 214 110 224 110 236 114 C 248 118 258 124 266 134 C 274 144 278 156 276 168 C 274 180 268 188 258 192 C 246 198 232 198 220 194 C 208 190 198 182 190 172 C 180 160 176 142 180 130 C 182 124 184 122 188 120 Z" fill="#d5976f" />
+    <g opacity="0.5">
+      <path d="M 40 240 C 90 260 140 270 190 268" fill="none" stroke="url(#koru)" stroke-width="16" stroke-linecap="round" />
+      <path d="M 120 80 C 150 60 190 52 230 60" fill="none" stroke="url(#koru)" stroke-width="12" stroke-linecap="round" />
+      <path d="M 286 52 Q 320 66 338 96" fill="none" stroke="url(#koru)" stroke-width="10" stroke-linecap="round" />
+    </g>
+  </g>
+</svg>

--- a/images/whanau-walk.svg
+++ b/images/whanau-walk.svg
@@ -1,0 +1,35 @@
+<svg width="400" height="300" viewBox="0 0 400 300" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Whānau walking together</title>
+  <desc id="desc">Stylised illustration of a Māori family taking a supportive walk along the waterfront.</desc>
+  <defs>
+    <linearGradient id="eveningSky" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#7fb7be" />
+      <stop offset="100%" stop-color="#114b5f" />
+    </linearGradient>
+    <linearGradient id="harbour" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#88d498" />
+      <stop offset="100%" stop-color="#317773" />
+    </linearGradient>
+  </defs>
+  <rect width="400" height="300" fill="url(#eveningSky)" />
+  <rect x="0" y="180" width="400" height="120" fill="url(#harbour)" />
+  <g fill="#ffffff" opacity="0.35">
+    <circle cx="80" cy="70" r="18" />
+    <circle cx="120" cy="50" r="10" />
+    <circle cx="340" cy="90" r="22" />
+  </g>
+  <g>
+    <path d="M40 244 C 44 226 60 212 86 210 C 112 208 138 220 148 238 L 108 268 C 82 264 56 258 40 244 Z" fill="#f2bb88" />
+    <path d="M82 152 C 102 130 138 134 154 158 C 166 178 162 206 144 222 C 124 240 94 240 76 222 C 56 204 58 172 82 152 Z" fill="#d08b5b" />
+    <path d="M154 212 C 166 186 194 170 226 172 C 256 174 282 194 292 222 C 300 246 288 270 266 280 L 198 280 C 176 262 162 238 154 212 Z" fill="#f5d0a2" />
+    <path d="M240 128 C 260 108 294 114 308 138 C 320 158 318 188 302 206 C 284 226 254 228 236 210 C 216 188 220 150 240 128 Z" fill="#9a5d37" />
+    <path d="M302 210 C 316 190 344 180 366 188 C 384 194 394 212 390 232 C 386 252 366 270 340 274 L 294 266 C 286 244 292 226 302 210 Z" fill="#f2bb88" />
+    <circle cx="108" cy="132" r="28" fill="#d08b5b" />
+    <circle cx="236" cy="122" r="32" fill="#9a5d37" />
+    <circle cx="322" cy="180" r="26" fill="#f2bb88" />
+    <path d="M96 124 C 110 112 130 116 138 132 C 142 140 140 152 132 160 C 120 162 108 162 98 156 C 88 150 84 140 86 130 C 90 128 92 126 96 124 Z" fill="#1c2626" opacity="0.4" />
+    <path d="M226 114 C 238 104 260 106 270 120 C 276 128 276 138 272 148 C 262 150 250 150 240 146 C 228 142 222 132 220 120 C 222 118 224 116 226 114 Z" fill="#101a1a" opacity="0.4" />
+    <path d="M314 172 C 324 162 340 164 348 174 C 354 180 356 188 354 198 C 346 200 338 204 330 204 C 320 204 312 198 308 190 C 310 184 310 178 314 172 Z" fill="#101a1a" opacity="0.35" />
+    <path d="M60 260 Q 90 248 122 252 Q 150 256 176 270 Q 214 290 260 288 Q 308 286 342 262" fill="none" stroke="#083d41" stroke-width="6" stroke-linecap="round" opacity="0.35" />
+  </g>
+</svg>

--- a/index.html
+++ b/index.html
@@ -40,16 +40,16 @@
   <div class="container">
     <div class="row">
       <div class="col-md-6">
-        <h4>FOR PATIENTS</h4>
-        <h2>OUR SERVICES</h2>
+        <h4>FOR OUR WHĀNAU</h4>
+        <h2>SUPPORTIVE SERVICES</h2>
         <hr />
-        <h5>PHYSIOTHERAPY SOLUTIONS</h5>
+        <h5>PHYSIOTHERAPY CARE FOR EVERYDAY LIFE</h5>
         <p>
-          Personalized physiotherapy treatments • Injury rehabilitation • Post-surgery recovery • Pain management • Corrective exercises for musculoskeletal issues • Improving mobility and flexibility • Helping you regain strength safely and effectively.
+          Whānau-focused plans for relaxing mirimiri, recovery after everyday knocks, strengthening for kaumātua, workplace and home injury support, and guidance that helps you move with ease alongside the people you love.
         </p>
       </div>
       <div class="col-md-6">
-        <figure><img src="images/about.jpg" alt="physiotherapy" class="img-fluid" /></figure>
+        <figure><img src="images/maori-massage.svg" alt="Māori hands providing a calming shoulder massage" class="img-fluid" /></figure>
       </div>
     </div>
   </div>
@@ -61,7 +61,7 @@
       <h2>ABOUT US</h2>
       <hr/>
       <p>
-        At Body Rehab Physiotherapy Limited, our team of experienced physiotherapists help patients recover from injuries, improve mobility, and manage pain effectively. We combine evidence-based treatments with personalized care to restore your body to its best possible condition.
+        At Body Rehab Physiotherapy Limited, our experienced kaimahi walk alongside tamariki, mātua, and kaumātua to restore comfortable movement. We blend evidence-based physiotherapy with manaakitanga so every person feels seen, supported, and confident in their daily life.
       </p>
     </div>
   </div>
@@ -76,21 +76,20 @@
         </div>
       </div>
       <div class="col-md-6 pr-5 pl-5">
-        <div class="card text-center"> 
-          <img class="card-img-top rounded-circle img-fluid" src="images/therapist1.jpg" alt="Therapist 1">
+        <div class="card text-center">
+          <img class="card-img-top rounded-circle img-fluid" src="images/therapist1.jpg" alt="Moana Rangi, clinic coordinator">
           <div class="card-body mb-5">
-            <h4 class="card-title">JANE DOE</h4>
-            <p class="card-text">Administration and patient support, managing appointments, ACC claims, and ensuring smooth communication between patients and the team.</p>
+            <h4 class="card-title">MOANA RANGI</h4>
+            <p class="card-text">Clinic coordinator ensuring whānau-friendly appointments, ACC support, and a warm welcome for every person who comes through our doors.</p>
           </div>
         </div>
       </div>
       <div class="col-md-6 pl-5 pr-5">
-        <div class="card text-center"> 
-          <img class="card-img-top rounded-circle img-fluid" src="images/therapist2.jpg" alt="Therapist 2">
+        <div class="card text-center">
+          <img class="card-img-top rounded-circle img-fluid" src="images/therapist2.jpg" alt="Wiremu Tai, lead physiotherapist">
           <div class="card-body mb-5">
-            <h4 class="card-title">JOHN SMITH</h4>
-            <p class="card-text">Physiotherapist specialising in recovery planning, exercise therapy, and tailored treatment programs to support patients in restoring strength and mobility.	
-</p>
+            <h4 class="card-title">WIREMU TAI</h4>
+            <p class="card-text">Lead physiotherapist offering mirimiri, mobility coaching, and tailored plans that empower everyday movement for kaumātua, workers, and active tamariki.</p>
           </div>
         </div>
       </div>
@@ -99,28 +98,28 @@
       <div class="col-md-4">
         <div class="card">
           <div class="card-body mb-4">
-            <h4 class="card-title">REHABILITATION</h4>
-            <p class="card-text">Comprehensive programs tailored to your specific injury and recovery goals.</p>
+            <h4 class="card-title">KAUMĀTUA STRETCH CLASSES</h4>
+            <p class="card-text">Gentle group sessions keeping kuia and koroua mobile, steady, and connected.</p>
           </div>
-          <img class="card-img-top img-fluid" src="images/gallery1.jpg" alt="rehab session"> 
+          <img class="card-img-top img-fluid" src="images/kaumatua-stretch.svg" alt="Kaumātua guided through a group stretch">
         </div>
       </div>
       <div class="col-md-4">
-        <div class="card"> 
-          <img class="card-img-top img-fluid" src="images/gallery2.jpg" alt="therapy session">
+        <div class="card">
+          <img class="card-img-top img-fluid" src="images/maori-massage.svg" alt="Brown Māori hands providing a therapeutic massage">
           <div class="card-body mt-4">
-            <h4 class="card-title">THERAPY SESSIONS</h4>
-            <p class="card-text">Guided treatment sessions with expert physiotherapists to restore strength and mobility.</p>
+            <h4 class="card-title">MIRIMIRI &amp; MASSAGE</h4>
+            <p class="card-text">Restorative hands-on care that soothes pākihiwi, backs, and tired muscles for everyday relief.</p>
           </div>
         </div>
       </div>
       <div class="col-md-4">
         <div class="card">
           <div class="card-body mb-4">
-            <h4 class="card-title">PAIN MANAGEMENT</h4>
-            <p class="card-text">Effective strategies and exercises to reduce discomfort and improve quality of life.</p>
+            <h4 class="card-title">WHĀNAU WALKING PLANS</h4>
+            <p class="card-text">Everyday movement strategies that bring the whānau together for steady progress.</p>
           </div>
-          <img class="card-img-top img-fluid" src="images/gallery3.jpg" alt="pain management session"> 
+          <img class="card-img-top img-fluid" src="images/whanau-walk.svg" alt="Whānau walking together along the waterfront">
         </div>
       </div>
     </div>
@@ -133,7 +132,7 @@
       <div class="col-md-3 footer1 d-flex">
         <div class="d-flex flex-wrap align-content-center"> 
           <a href="#"><img src="images/logo.png" alt="Body Rehab Physiotherapy Limited" /></a>
-          <p>Providing expert physiotherapy services for rehabilitation, recovery, and improved mobility.</p>
+          <p>Providing expert physiotherapy grounded in manaakitanga to restore strength, comfort, and confidence for everyday life.</p>
           <p>&copy; 2025 Body Rehab Physiotherapy Limited. All rights reserved.</p>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- update services and about copy to highlight everyday whānau, tamariki, and kaumātua care
- rename team bios to Moana Rangi and Wiremu Tai with welcoming descriptions for community visitors
- add Māori-inspired SVG illustrations for mirimiri, kaumātua stretch, and whānau walking scenes

## Testing
- python3 -m http.server 8000 (manual verification)


------
https://chatgpt.com/codex/tasks/task_e_68e4aaa9431c83329d39ceb2c7565a06