### PR TITLE
Restore brand palette with refreshed imagery

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -4,11 +4,11 @@ Based on Fox template
 */
 
 /* Import Google Font */
-@import url('https://fonts.googleapis.com/css2?family=Comic+Neue:wght@400;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Lato:wght@300;400;700&display=swap');
 
 /* ---------------- Body ---------------- */
 body {
-  font-family: 'Comic Neue', cursive, sans-serif;
+  font-family: 'Lato', sans-serif;
   overflow-x: hidden;
   background-color: #202220;
   color: #F1F1F1;
@@ -22,6 +22,26 @@ body {
   background-position: center;
   background-size: cover;
   padding-bottom: 100px;
+  position: relative;
+  overflow: hidden;
+}
+
+.parallax-window2 {
+  background-color: #202220;
+}
+
+.parallax-window2::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(32, 34, 32, 0.85), rgba(42, 44, 42, 0.7)),
+              radial-gradient(circle at 20% 20%, rgba(255, 209, 102, 0.18), transparent 60%);
+  z-index: 0;
+}
+
+.parallax-window2 > * {
+  position: relative;
+  z-index: 1;
 }
 
 /* ---------------- Navbar ---------------- */
@@ -33,8 +53,7 @@ nav {
   font-size: 16px;
   text-transform: uppercase;
   color: #F5E6B8;
-  font-weight: 700;
-  /* transition removed */
+  font-weight: 600;
 }
 
 .navbar-nav a:hover {
@@ -44,10 +63,9 @@ nav {
 .navbar-nav .btn-danger {
   background: #F5E6B8;
   border-color: #F5E6B8;
-  border-radius: 0;
+  border-radius: 40px;
   color: #202220;
-  font-weight: bold;
-  /* transition removed */
+  font-weight: 700;
 }
 
 .navbar-nav .btn-danger:hover {
@@ -60,19 +78,19 @@ nav {
 a, a:hover {
   color: #FFD166;
   text-decoration: none;
-  /* transition removed */
 }
 
 /* ---------------- Banner ---------------- */
 .fh5co-banner-text-box {
   position: relative;
   display: inline-block;
-  margin: 250px auto 0 auto;
-  padding: 30px 40px;
-  background: rgba(32, 34, 32, 0.7);
-  border-radius: 10px;
-  max-width: 90%;
+  margin: 220px auto 80px auto;
+  padding: 36px 44px;
+  background: rgba(32, 34, 32, 0.78);
+  border-radius: 14px;
+  max-width: 720px;
   text-align: center;
+  box-shadow: 0 22px 60px rgba(12, 12, 12, 0.55);
 }
 
 .fh5co-banner-text-box .quote-box {
@@ -82,34 +100,43 @@ a, a:hover {
 
 .fh5co-banner-text-box .quote-box h2 {
   font-weight: 700;
-  font-size: 48px;
+  font-size: 46px;
   line-height: 1.2em;
   margin: 0;
   color: #FFD166;
-  text-align: center;
 }
 
 .fh5co-banner-text-box .quote-box h2 span {
   display: block;
-  font-size: 42px;
+  font-size: 30px;
   color: #F5E6B8;
-  margin-top: 5px;
+  margin-top: 12px;
+  letter-spacing: 2px;
+}
+
+.banner-lead {
+  margin: 22px auto 32px auto;
+  font-size: 18px;
+  max-width: 520px;
+  line-height: 1.7em;
+  color: #F1F1F1;
 }
 
 .fh5co-banner-text-box a {
-  color: #FFD166;
-  border: 2px solid #FFD166;
-  border-radius: 0;
-  min-width: 150px;
-  font-weight: bold;
-  padding: 10px 20px;
-  /* transition removed */
+  color: #202220;
+  border: none;
+  border-radius: 40px;
+  min-width: 180px;
+  font-weight: 700;
+  padding: 14px 32px;
+  display: inline-block;
+  background: #FFD166;
+  box-shadow: 0 10px 25px rgba(255, 209, 102, 0.35);
 }
 
 .fh5co-banner-text-box a:hover {
-  color: #F5E6B8;
-  border-color: #F5E6B8;
-  background: transparent;
+  background: #F5E6B8;
+  color: #202220;
 }
 
 /* ---------------- Sections ---------------- */
@@ -118,7 +145,7 @@ a, a:hover {
   background-repeat: no-repeat;
   background-position: center;
   background-size: cover;
-  padding: 50px 0 30px 0;
+  padding: 70px 0 50px 0;
   position: relative;
 }
 
@@ -128,7 +155,7 @@ a, a:hover {
   position: absolute;
   top: 0; left: 0;
   width: 100%; height: 100%;
-  background: rgba(32,34,32,0.7);
+  background: rgba(32, 34, 32, 0.7);
   z-index: 1;
 }
 
@@ -137,7 +164,7 @@ a, a:hover {
   color: #FFD166;
   font-weight: 700;
   font-size: 40px;
-  margin-bottom: 0;
+  margin-bottom: 10px;
   position: relative;
   z-index: 2;
 }
@@ -156,8 +183,8 @@ a, a:hover {
 
 hr {
   border-color: #FFD166;
-  border-width: 5px;
-  max-width: 100px;
+  border-width: 4px;
+  max-width: 110px;
   margin-left: 0;
   border-radius: 5px;
   position: relative;
@@ -165,6 +192,7 @@ hr {
 }
 
 /* ---------------- Content Boxes ---------------- */
+
 .fh5co-content-box {
   background: #2A2C2A;
   padding-bottom: 100px;
@@ -175,27 +203,69 @@ hr {
   display: block;
 }
 
+.fh5co-content-box figure,
+.fh5co-content-box .card-img-top {
+  background-color: transparent;
+}
+
+.fh5co-content-box .card {
+  background: rgba(47, 49, 47, 0.95);
+  border: 1px solid rgba(255, 209, 102, 0.25);
+  border-radius: 18px;
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.35);
+  color: #F5E6B8;
+  overflow: hidden;
+}
+
+.fh5co-content-box .card-body {
+  background: transparent;
+  color: inherit;
+  padding: 25px;
+}
+
+.fh5co-content-box .card-img-top.rounded-circle {
+  padding: 10px;
+  background-color: rgba(32, 34, 32, 0.95);
+  border: 3px solid rgba(255, 209, 102, 0.4);
+}
+
+
 .fh5co-content-box .trainers {
   position: relative;
-  padding: 50px 0;
-  margin: 70px 0;
-  background: #282A25 url("../images/gym2.jpg") center/cover no-repeat;
+  padding: 60px 0;
+  margin: 80px 0 60px 0;
+  background: #1f201f url("../images/team-community.svg") center/cover no-repeat;
+  border-radius: 28px;
+  overflow: hidden;
+}
+
+.fh5co-content-box .trainers::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(120deg, rgba(32, 34, 32, 0.88), rgba(42, 44, 42, 0.62));
+}
+
+.fh5co-content-box .trainers > * {
+  position: relative;
+  z-index: 1;
 }
 
 .fh5co-content-box .trainers .card-body {
-  background: rgba(64, 67, 50, 0.95);
-  border-radius: 15px;
-  padding: 30px 20px 50px 20px;
-  margin-top: 30px;
+  background: rgba(47, 49, 47, 0.95);
+  border-radius: 18px;
+  padding: 30px 25px 45px 25px;
+  margin-top: 20px;
   color: #F5E6B8;
   position: relative;
+  box-shadow: 0 18px 35px rgba(0, 0, 0, 0.35);
 }
 
 .fh5co-content-box .trainers .card-body::before {
   content: "";
   position: absolute;
   border: 20px solid transparent;
-  border-bottom-color: rgba(64, 67, 50, 0.95);
+  border-bottom-color: rgba(47, 49, 47, 0.95);
   margin-top: -70px;
   margin-left: -15px;
 }
@@ -204,7 +274,7 @@ hr {
 footer {
   background: #202220;
   color: #F5E6B8;
-  padding: 50px 20px 20px 20px;
+  padding: 60px 20px 30px 20px;
   position: relative;
 }
 
@@ -220,22 +290,21 @@ footer input[type='email'] {
   border: none;
   border-bottom: 2px solid #FFD166;
   color: #F1F1F1;
-  padding: 5px 0;
+  padding: 6px 0;
 }
 
 footer input[type='text']:focus,
 footer input[type='email']:focus {
   outline: none;
-  border-color: #FFD166;
+  border-color: #F5E6B8;
 }
 
 footer .btn {
   min-width: 150px;
-  border-radius: 0;
+  border-radius: 40px;
   background: #FFD166;
   color: #202220;
-  font-weight: bold;
-  /* transition removed */
+  font-weight: 700;
 }
 
 footer .btn:hover {
@@ -243,11 +312,32 @@ footer .btn:hover {
   color: #202220;
 }
 
+.social-links .nav {
+  display: flex;
+  gap: 10px;
+}
+
+.social-links .nav a {
+  background: rgba(47, 49, 47, 0.95);
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  padding: 0;
+}
+
+.social-links .nav img {
+  width: 20px;
+  height: 20px;
+}
+
 /* ---------------- Media Queries ---------------- */
 @media (max-width: 991px) {
   .fh5co-banner-text-box {
-    padding: 20px 25px;
-    margin-top: 180px;
+    padding: 28px 30px;
+    margin-top: 140px;
   }
   .fh5co-banner-text-box h2 {
     font-size: 36px;
@@ -255,16 +345,25 @@ footer .btn:hover {
   .fh5co-banner-text-box h2 span {
     font-size: 30px;
   }
+  .banner-lead {
+    font-size: 16px;
+    margin: 18px auto 26px auto;
+  }
 }
 
 @media (max-width: 767px) {
   .fh5co-banner-text-box {
-    padding: 15px 20px;
+    padding: 22px 20px;
+    margin-top: 110px;
   }
   .fh5co-banner-text-box h2 {
     font-size: 28px;
   }
   .fh5co-banner-text-box h2 span {
     font-size: 24px;
+  }
+  .banner-lead {
+    font-size: 15px;
+    margin: 16px auto 24px auto;
   }
 }

--- a/images/gallery-massage.svg
+++ b/images/gallery-massage.svg
@@ -1,0 +1,46 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 520">
+  <defs>
+    <linearGradient id="massageBg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1f1f20"/>
+      <stop offset="100%" stop-color="#2c2f2c"/>
+    </linearGradient>
+    <linearGradient id="massageHighlight" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#ffd166"/>
+      <stop offset="100%" stop-color="#f5e6b8"/>
+    </linearGradient>
+  </defs>
+  <rect width="800" height="520" rx="24" fill="url(#massageBg)"/>
+  <g opacity="0.22" fill="#ffd166">
+    <circle cx="620" cy="120" r="120"/>
+    <circle cx="180" cy="200" r="100"/>
+  </g>
+  <g fill="#101110" opacity="0.45">
+    <path d="M60 428c140-80 240-116 340-116s200 36 340 116v92H60z"/>
+  </g>
+  <g>
+    <ellipse cx="240" cy="432" rx="120" ry="30" fill="#0a0a0a" opacity="0.4"/>
+    <ellipse cx="520" cy="448" rx="132" ry="32" fill="#0a0a0a" opacity="0.36"/>
+  </g>
+  <g>
+    <path d="M230 220c-42 0-74 36-74 82s32 86 74 86 76-40 76-86-34-82-76-82z" fill="#d69a5c"/>
+    <path d="M188 230c-16 42-2 104 40 128s86-8 100-48c12-34-4-72-26-84-34-18-82-26-114 4z" fill="#3b3d39"/>
+    <path d="M232 202c-20 0-40 12-54 32-10 16 6 34 24 26 16-6 26-16 40-16s24 10 40 16c18 8 34-10 24-26-12-20-34-32-54-32z" fill="#1c1d1c"/>
+    <circle cx="204" cy="276" r="18" fill="#202220"/>
+    <circle cx="260" cy="276" r="18" fill="#202220"/>
+    <path d="M212 318c16 14 36 14 52 0" fill="none" stroke="#a06c38" stroke-width="8" stroke-linecap="round"/>
+  </g>
+  <g>
+    <path d="M320 352l-46 40 70 44 68-46z" fill="#ffd166" opacity="0.7"/>
+    <path d="M332 304c-24 0-36 22-30 44l34 88h104l-42-126c-6-16-32-6-32 12 0-12-16-18-34-18z" fill="#f5e6b8"/>
+    <path d="M332 304c16-18 52-20 76-10l38 22 84-32c26-10 54 8 54 36v56l-116 44-78-36-58-80z" fill="#5f6f6b"/>
+  </g>
+  <g>
+    <path d="M520 200c-34 0-62 30-62 70s28 70 62 70 60-30 60-70-26-70-60-70z" fill="#5f6f6b"/>
+    <path d="M480 206c-14 46 4 104 44 122s84-10 96-56c8-32-6-64-28-74-30-14-84-20-112 8z" fill="#3c3d3b"/>
+    <path d="M514 182c-20 0-40 12-52 30-10 16 6 34 24 26 18-6 28-16 42-16s24 10 40 16c18 8 34-10 24-26-12-18-34-30-58-30z" fill="#151715"/>
+    <circle cx="490" cy="246" r="16" fill="#202220"/>
+    <circle cx="542" cy="246" r="16" fill="#202220"/>
+    <path d="M498 282c14 12 34 12 48 0" fill="none" stroke="#754a24" stroke-width="8" stroke-linecap="round"/>
+  </g>
+  <path d="M472 328l-64 24 48 84 136-46-28-60c-12-24-44-36-70-24l-22 10z" fill="url(#massageHighlight)"/>
+</svg>

--- a/images/gallery-recovery.svg
+++ b/images/gallery-recovery.svg
@@ -1,0 +1,46 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 520">
+  <defs>
+    <linearGradient id="recoveryBg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1f211f"/>
+      <stop offset="100%" stop-color="#2d302d"/>
+    </linearGradient>
+    <linearGradient id="highlight" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#ffd166"/>
+      <stop offset="100%" stop-color="#f5e6b8"/>
+    </linearGradient>
+  </defs>
+  <rect width="800" height="520" fill="url(#recoveryBg)" rx="24"/>
+  <g opacity="0.18" fill="#ffd166">
+    <circle cx="620" cy="140" r="120"/>
+    <circle cx="200" cy="360" r="160"/>
+  </g>
+  <g fill="#0f100f" opacity="0.4">
+    <path d="M40 420c120-90 220-130 320-130s200 46 320 130v100H40z"/>
+  </g>
+  <g>
+    <ellipse cx="240" cy="440" rx="110" ry="28" fill="#0c0c0c" opacity="0.45"/>
+    <ellipse cx="510" cy="456" rx="120" ry="32" fill="#0c0c0c" opacity="0.38"/>
+  </g>
+  <g fill="#d69a5c">
+    <path d="M226 274c-24 10-38 38-28 62l36 90 110-30-20-78c-6-26-34-42-60-30l-38 18z"/>
+    <path d="M320 318l24 108 100 12-18-124z" fill="#5f6f6b"/>
+  </g>
+  <g>
+    <path d="M240 180c-40 0-72 34-72 76s32 78 72 78 72-36 72-78-32-76-72-76z" fill="#5f6f6b"/>
+    <path d="M204 186c-16 44-4 108 36 132s84-10 100-54c12-34-4-70-28-82-30-16-84-22-108 4z" fill="#3b3d39"/>
+    <path d="M248 160c-20 0-40 12-52 30-10 14 2 36 18 30 20-8 30-18 46-18s26 10 46 18c16 6 30-14 18-30-12-18-30-30-54-30z" fill="#1d1f1d"/>
+    <circle cx="214" cy="234" r="16" fill="#202220"/>
+    <circle cx="268" cy="234" r="16" fill="#202220"/>
+    <path d="M222 272c14 12 34 12 48 0" fill="none" stroke="#a06c38" stroke-width="8" stroke-linecap="round"/>
+  </g>
+  <g>
+    <path d="M480 208c-30 0-54 28-54 64s24 64 54 64 54-28 54-64-24-64-54-64z" fill="#3c4541"/>
+    <path d="M444 214c-12 44 6 96 38 112s68-6 80-46c10-32-6-64-26-74-28-12-70-18-92 8z" fill="#2a2c2a"/>
+    <path d="M474 188c-18 0-38 10-50 26-10 16 6 32 22 26 16-6 26-16 40-16s24 10 40 16c16 6 34-10 22-26-10-16-32-26-50-26z" fill="#151715"/>
+    <circle cx="454" cy="256" r="14" fill="#202220"/>
+    <circle cx="502" cy="256" r="14" fill="#202220"/>
+    <path d="M460 292c10 10 26 10 36 0" fill="none" stroke="#754a24" stroke-width="6" stroke-linecap="round"/>
+  </g>
+  <path d="M320 318l70-26c38-14 82 4 100 42l32 70-98 38-40-84-64-40z" fill="url(#highlight)"/>
+  <path d="M226 274l72 44 42-16c28-10 58 2 74 26l54 78-34 16-48-70-68-38-96-40z" fill="#f5e6b8" opacity="0.6"/>
+</svg>

--- a/images/gallery-whanau.svg
+++ b/images/gallery-whanau.svg
@@ -1,0 +1,50 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 520">
+  <defs>
+    <linearGradient id="walkBg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#202220"/>
+      <stop offset="100%" stop-color="#2f312f"/>
+    </linearGradient>
+    <linearGradient id="walkHighlight" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#ffd166"/>
+      <stop offset="100%" stop-color="#f5e6b8"/>
+    </linearGradient>
+  </defs>
+  <rect width="800" height="520" rx="24" fill="url(#walkBg)"/>
+  <g opacity="0.22" fill="#ffd166">
+    <circle cx="600" cy="140" r="130"/>
+    <circle cx="160" cy="140" r="110"/>
+  </g>
+  <g fill="#0d0e0d" opacity="0.5">
+    <path d="M0 360c120-90 200-130 320-130s220 40 320 130v160H0z"/>
+  </g>
+  <g>
+    <ellipse cx="190" cy="430" rx="110" ry="28" fill="#0a0a0a" opacity="0.4"/>
+    <ellipse cx="390" cy="448" rx="120" ry="30" fill="#0a0a0a" opacity="0.36"/>
+    <ellipse cx="600" cy="430" rx="110" ry="26" fill="#0a0a0a" opacity="0.34"/>
+  </g>
+  <g>
+    <path d="M160 220c-36 0-62 32-62 74s26 76 62 76 64-34 64-76-28-74-64-74z" fill="#d69a5c"/>
+    <path d="M130 224c-14 42-4 100 30 120s78-6 92-44c10-32-4-66-22-76-30-16-76-22-100 0z" fill="#3b3d39"/>
+    <path d="M168 198c-18 0-38 10-50 28-10 14 4 32 20 26 14-6 24-14 38-14s24 8 38 14c18 6 30-12 20-26-12-18-32-28-66-28z" fill="#1c1d1c"/>
+    <circle cx="144" cy="268" r="16" fill="#202220"/>
+    <circle cx="194" cy="268" r="16" fill="#202220"/>
+    <path d="M150 304c12 12 30 12 42 0" fill="none" stroke="#a06c38" stroke-width="8" stroke-linecap="round"/>
+  </g>
+  <g>
+    <path d="M320 210c-34 0-58 32-58 70s24 72 58 72 60-34 60-72-26-70-60-70z" fill="#c4874e"/>
+    <path d="M290 214c-12 40-2 94 30 116s72-8 84-46c10-30-6-60-24-72-26-14-70-20-90 2z" fill="#3c3d3b"/>
+    <path d="M326 190c-18 0-34 12-46 28-10 14 4 32 20 26 14-6 24-14 36-14s22 8 36 14c16 6 30-12 20-26-12-18-30-28-66-28z" fill="#151715"/>
+    <circle cx="304" cy="256" r="14" fill="#202220"/>
+    <circle cx="346" cy="256" r="14" fill="#202220"/>
+    <path d="M310 292c10 10 24 10 34 0" fill="none" stroke="#8d5b32" stroke-width="6" stroke-linecap="round"/>
+  </g>
+  <g>
+    <path d="M534 198c-34 0-60 32-60 72s26 74 60 74 62-34 62-74-28-72-62-72z" fill="#8d5b32"/>
+    <path d="M504 202c-14 42-2 98 32 118s76-8 90-46c12-32-2-66-22-78-26-16-74-22-100 6z" fill="#3b3d39"/>
+    <path d="M538 176c-18 0-38 12-50 28-10 16 6 32 20 26 16-6 24-14 36-14s22 8 36 14c16 6 32-10 22-26-12-18-32-28-64-28z" fill="#1c1d1c"/>
+    <circle cx="516" cy="248" r="16" fill="#202220"/>
+    <circle cx="566" cy="248" r="16" fill="#202220"/>
+    <path d="M522 284c12 12 28 12 40 0" fill="none" stroke="#8d5b32" stroke-width="8" stroke-linecap="round"/>
+  </g>
+  <path d="M164 348l76 42 36-22c32-20 72-16 100 10l20 18 96-40c28-10 60 4 72 32l18 46-94 32-88-36-38 26-92-60-86-52z" fill="url(#walkHighlight)"/>
+</svg>

--- a/images/hero-balance.svg
+++ b/images/hero-balance.svg
@@ -1,0 +1,70 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1440 900">
+  <defs>
+    <linearGradient id="bgGradient" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#1b1d1b"/>
+      <stop offset="50%" stop-color="#242624"/>
+      <stop offset="100%" stop-color="#2f312f"/>
+    </linearGradient>
+    <linearGradient id="sunGlow" x1="0.2" y1="0" x2="0.8" y2="1">
+      <stop offset="0%" stop-color="rgba(255,209,102,0.6)"/>
+      <stop offset="100%" stop-color="rgba(255,209,102,0)"/>
+    </linearGradient>
+    <linearGradient id="floorGradient" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#161716"/>
+      <stop offset="100%" stop-color="#0c0d0c"/>
+    </linearGradient>
+    <linearGradient id="shirtGradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#ffd166"/>
+      <stop offset="100%" stop-color="#f5e6b8"/>
+    </linearGradient>
+    <linearGradient id="patientTop" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#5f6f6b"/>
+      <stop offset="100%" stop-color="#3c4541"/>
+    </linearGradient>
+    <filter id="softShadow" x="-0.2" y="-0.2" width="1.4" height="1.4">
+      <feDropShadow dx="0" dy="14" stdDeviation="24" flood-color="#000" flood-opacity="0.35"/>
+    </filter>
+  </defs>
+  <rect width="1440" height="900" fill="url(#bgGradient)"/>
+  <ellipse cx="360" cy="220" rx="280" ry="200" fill="url(#sunGlow)" opacity="0.6"/>
+  <rect y="620" width="1440" height="280" fill="url(#floorGradient)"/>
+  <g opacity="0.25" fill="#343634">
+    <path d="M120 520c70-90 150-140 260-140s210 48 310 48 204-38 290-32 152 52 220 152l-1080 0z"/>
+    <path d="M80 610c80-80 170-110 250-110s148 22 230 22 182-30 260-24 140 42 210 122H80z"/>
+  </g>
+  <g filter="url(#softShadow)">
+    <path d="M510 640c0-92 42-170 126-170h206c80 0 126 74 126 170 0 114-78 178-198 178H708c-112 0-198-68-198-178z" fill="#2d2f2d"/>
+  </g>
+  <g>
+    <ellipse cx="820" cy="778" rx="120" ry="26" fill="#151615" opacity="0.5"/>
+    <ellipse cx="590" cy="790" rx="110" ry="24" fill="#101110" opacity="0.45"/>
+  </g>
+  <g id="therapist">
+    <path d="M640 320c-24 0-44 20-44 44s20 44 44 44 44-20 44-44-20-44-44-44z" fill="#d69a5c"/>
+    <path d="M620 396c-58 22-82 86-70 176l30 210h140l18-154-44-32-12-104-62-96z" fill="url(#shirtGradient)"/>
+    <path d="M646 308c-20 0-36 10-46 26-8 14-6 34 12 40 16 6 26-6 38-16 14-12 34-16 56-12 14 4 28 0 32-10 6-12-6-26-20-32-26-10-46-12-72 4z" fill="#3c3d3b"/>
+    <path d="M614 680l-26 146h86l6-146h-66z" fill="#2a2c2a"/>
+    <path d="M720 680l-6 146h88l24-104-70-42-36 0z" fill="#242624"/>
+    <path d="M588 826l-6 30h114l2-30H588z" fill="#0f100f"/>
+    <path d="M798 826l-12 32h116l10-32h-114z" fill="#0d0d0d"/>
+  </g>
+  <g id="patient">
+    <path d="M878 348c-28 0-52 24-52 54s24 54 52 54 52-24 52-54-22-54-52-54z" fill="#b57640"/>
+    <path d="M844 426c-70 16-108 90-104 198l12 144h244l-14-170-34-30-12-98-92-44z" fill="url(#patientTop)"/>
+    <path d="M870 320c-24 0-42 8-58 26-12 14-8 34 10 40 18 8 34-12 56-18 26-6 52 10 74 6 18-2 24-22 14-36-22-28-62-28-96-18z" fill="#2f302f"/>
+    <path d="M860 662l-6 108 100 4-8-112H860z" fill="#202220"/>
+    <path d="M960 664l10 148h110l-48-138-72-10z" fill="#191a19"/>
+    <path d="M852 766l-12 58h124l4-56-116-2z" fill="#0c0d0c"/>
+    <path d="M978 812l-4 46h138l-34-72-100 26z" fill="#0a0a0a"/>
+  </g>
+  <g fill="#ffd166" opacity="0.24">
+    <circle cx="220" cy="720" r="90"/>
+    <circle cx="1180" cy="280" r="140"/>
+    <circle cx="1280" cy="620" r="70"/>
+  </g>
+  <g fill="#3a3c3a" opacity="0.5">
+    <rect x="160" y="280" width="120" height="340" rx="18"/>
+    <rect x="320" y="260" width="140" height="380" rx="22"/>
+    <rect x="1240" y="300" width="120" height="320" rx="18"/>
+  </g>
+</svg>

--- a/images/icon-facebook.svg
+++ b/images/icon-facebook.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="fbGradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#ffd166"/>
+      <stop offset="100%" stop-color="#f5e6b8"/>
+    </linearGradient>
+  </defs>
+  <circle cx="32" cy="32" r="32" fill="rgba(32,34,32,0.9)"/>
+  <path d="M35 14c6 0 11 2 11 2l-2 10h-9v6h8l-2 10h-6v18h-12V42h-6v-10h6v-6c0-8 5-12 12-12z" fill="url(#fbGradient)"/>
+</svg>

--- a/images/icon-instagram.svg
+++ b/images/icon-instagram.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="igGradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#ffd166"/>
+      <stop offset="100%" stop-color="#f5e6b8"/>
+    </linearGradient>
+  </defs>
+  <circle cx="32" cy="32" r="32" fill="rgba(32,34,32,0.9)"/>
+  <rect x="18" y="18" width="28" height="28" rx="10" ry="10" fill="none" stroke="url(#igGradient)" stroke-width="4"/>
+  <circle cx="32" cy="32" r="8" fill="none" stroke="url(#igGradient)" stroke-width="4"/>
+  <circle cx="40" cy="24" r="3" fill="url(#igGradient)"/>
+</svg>

--- a/images/massage-support.svg
+++ b/images/massage-support.svg
@@ -1,0 +1,73 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 560" role="img" aria-labelledby="title desc">
+  <title id="title">Massage therapy with brown hands supporting a shoulder</title>
+  <desc id="desc">Illustrated close up of a physiotherapist gently massaging a client's shoulder with warm brown hands in a calm treatment room.</desc>
+  <defs>
+    <linearGradient id="bgGrad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#f4fbff" />
+      <stop offset="100%" stop-color="#d2e4f2" />
+    </linearGradient>
+    <linearGradient id="sheetGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.95" />
+      <stop offset="100%" stop-color="#dfe9f2" stop-opacity="0.9" />
+    </linearGradient>
+    <linearGradient id="skinDeep" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#a6673e" />
+      <stop offset="100%" stop-color="#6b3c21" />
+    </linearGradient>
+    <linearGradient id="skinLight" x1="0" y1="0" x2="0.8" y2="0.8">
+      <stop offset="0%" stop-color="#c8804c" />
+      <stop offset="100%" stop-color="#814829" />
+    </linearGradient>
+    <linearGradient id="armGrad" x1="0" y1="0" x2="1" y2="0.2">
+      <stop offset="0%" stop-color="#d99a64" />
+      <stop offset="80%" stop-color="#9a5a32" />
+    </linearGradient>
+    <linearGradient id="shirtGrad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#4d87a6" />
+      <stop offset="100%" stop-color="#25516a" />
+    </linearGradient>
+    <linearGradient id="tableGrad" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#9dc4d8" />
+      <stop offset="100%" stop-color="#6d8aa2" />
+    </linearGradient>
+    <filter id="softShadow" x="-0.2" y="-0.2" width="1.4" height="1.4">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="6" />
+      <feOffset dx="0" dy="6" result="offsetblur" />
+      <feFlood flood-color="#1c2d3a" flood-opacity="0.2" />
+      <feComposite in2="offsetblur" operator="in" />
+      <feMerge>
+        <feMergeNode />
+        <feMergeNode in="SourceGraphic" />
+      </feMerge>
+    </filter>
+  </defs>
+  <rect width="800" height="560" fill="url(#bgGrad)" />
+  <path d="M0 420 Q160 360 320 380 T800 360 V560 H0 Z" fill="url(#sheetGrad)" />
+  <g filter="url(#softShadow)">
+    <path d="M120 280 Q200 240 280 260 T480 240 Q560 240 620 260 T700 320 L640 360 Q560 330 480 320 T280 340 Q200 360 160 380 Z" fill="url(#tableGrad)" opacity="0.55" />
+  </g>
+  <g>
+    <path d="M250 320 Q310 260 380 260 Q430 262 470 288 Q520 320 520 360 Q520 404 480 430 T380 460 Q320 458 270 430 Q230 408 230 360 Q230 332 250 320 Z" fill="url(#skinDeep)" />
+    <path d="M252 328 Q300 292 366 292 Q414 292 454 320 Q498 350 498 376 Q498 402 462 420 T374 440 Q320 440 278 418 Q244 400 244 368 Q244 340 252 328 Z" fill="rgba(255,255,255,0.15)" />
+  </g>
+  <g>
+    <path d="M430 206 Q450 180 494 182 Q540 184 574 210 T632 280 Q650 320 622 348 Q596 374 548 360 Q508 348 476 318 Q438 282 420 250 Q408 226 430 206 Z" fill="url(#shirtGrad)" />
+    <path d="M360 206 Q320 212 300 240 Q288 258 296 284 Q304 312 330 318 Q360 326 390 320 T450 286 Q468 260 456 230 Q444 202 406 200 Q380 198 360 206 Z" fill="url(#armGrad)" />
+    <path d="M320 282 Q340 268 372 268 Q398 270 422 288 Q450 310 454 334 Q456 360 432 378 Q408 398 370 398 Q330 398 308 376 Q288 354 292 326 Q296 300 320 282 Z" fill="url(#skinLight)" />
+    <path d="M402 232 Q414 214 440 210 Q460 210 476 222 T508 260 Q520 280 504 294 Q488 310 466 300 T422 266 Q404 248 402 232 Z" fill="url(#skinDeep)" />
+  </g>
+  <g>
+    <path d="M408 328 Q448 300 486 300 Q526 300 560 320 T620 372 Q634 392 620 412 Q606 432 576 428 T510 402 Q476 382 450 362 Q428 346 408 328 Z" fill="url(#skinLight)" />
+    <path d="M356 356 Q388 332 436 334 Q468 338 500 360 T556 408 Q570 426 556 440 Q540 454 512 446 T448 410 Q408 384 380 364 Z" fill="url(#skinDeep)" />
+    <path d="M528 330 Q550 318 584 324 Q612 332 640 354 T684 402 Q694 420 682 436 Q670 450 646 444 T596 416 Q560 392 532 364 Q518 350 528 330 Z" fill="url(#skinDeep)" />
+  </g>
+  <g opacity="0.2">
+    <path d="M300 352 Q380 300 458 316 T588 380" fill="none" stroke="#ffffff" stroke-width="18" stroke-linecap="round" />
+    <path d="M330 384 Q402 342 470 352 T572 404" fill="none" stroke="#ffffff" stroke-width="14" stroke-linecap="round" />
+  </g>
+  <g opacity="0.18">
+    <circle cx="120" cy="120" r="6" fill="#ffffff" />
+    <circle cx="680" cy="160" r="8" fill="#ffffff" />
+    <circle cx="700" cy="80" r="5" fill="#ffffff" />
+  </g>
+</svg>

--- a/images/team-community.svg
+++ b/images/team-community.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 900">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1d1f1d"/>
+      <stop offset="50%" stop-color="#252725"/>
+      <stop offset="100%" stop-color="#303230"/>
+    </linearGradient>
+    <linearGradient id="dusk" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="rgba(255,209,102,0.55)"/>
+      <stop offset="100%" stop-color="rgba(255,209,102,0)"/>
+    </linearGradient>
+  </defs>
+  <rect width="1600" height="900" fill="url(#bg)"/>
+  <rect width="1600" height="360" fill="url(#dusk)"/>
+  <g opacity="0.18" fill="#ffd166">
+    <circle cx="240" cy="160" r="140"/>
+    <circle cx="1280" cy="220" r="180"/>
+  </g>
+  <g fill="#121312" opacity="0.6">
+    <path d="M0 620c160-120 300-180 420-180s260 78 380 78 260-58 380-58 220 80 420 200v240H0z"/>
+  </g>
+  <g fill="#ffd166" opacity="0.14">
+    <path d="M120 760c80-70 180-110 280-110s220 46 300 42 220-60 320-44 210 98 320 182H120z"/>
+  </g>
+  <g stroke="#f5e6b8" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" fill="none" opacity="0.3">
+    <path d="M160 520c60-20 120 0 160 60s120 80 180 40 140-20 180 40 100 80 160 20 140-60 220-10 160 40 220-20 160-60 200 0"/>
+  </g>
+  <g fill="#ffd166" opacity="0.3">
+    <rect x="260" y="300" width="140" height="260" rx="24"/>
+    <rect x="470" y="340" width="120" height="220" rx="24"/>
+    <rect x="720" y="280" width="160" height="280" rx="32"/>
+    <rect x="1020" y="320" width="140" height="260" rx="28"/>
+    <rect x="1240" y="360" width="120" height="200" rx="24"/>
+  </g>
+</svg>

--- a/images/team-emma.svg
+++ b/images/team-emma.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 520 520">
+  <defs>
+    <linearGradient id="avatarBgEmma" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#2a2c2a"/>
+      <stop offset="100%" stop-color="#1f201f"/>
+    </linearGradient>
+    <linearGradient id="topEmma" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#ffd166"/>
+      <stop offset="100%" stop-color="#f5e6b8"/>
+    </linearGradient>
+  </defs>
+  <circle cx="260" cy="260" r="250" fill="url(#avatarBgEmma)"/>
+  <circle cx="260" cy="180" r="120" fill="#c18753"/>
+  <path d="M200 170c-10 60 0 140 60 140s70-80 60-140c-8-42-38-74-60-74s-54 32-60 74z" fill="#f3d2a4"/>
+  <path d="M152 420c22-70 70-110 108-110s88 40 108 110c10 36-18 72-56 72h-104c-38 0-68-36-56-72z" fill="url(#topEmma)"/>
+  <path d="M184 246c18 34 50 52 76 52s54-18 76-52c-10-16-18-36-18-56 0-36-22-64-58-64s-58 28-58 64c0 20-8 40-18 56z" fill="#3b3d39"/>
+  <path d="M178 158c10-40 46-68 82-68s70 28 82 68c8 24-12 46-32 36-22-12-32-20-50-20s-26 8-50 20c-20 10-38-12-32-36z" fill="#1c1d1c"/>
+  <path d="M208 312c0 22 22 40 52 40s52-18 52-40" fill="none" stroke="#202220" stroke-width="10" stroke-linecap="round"/>
+  <circle cx="220" cy="230" r="18" fill="#202220"/>
+  <circle cx="300" cy="230" r="18" fill="#202220"/>
+  <circle cx="228" cy="226" r="8" fill="#f5f5f5" opacity="0.7"/>
+  <circle cx="308" cy="226" r="8" fill="#f5f5f5" opacity="0.7"/>
+  <path d="M240 280c12 8 28 8 40 0" fill="none" stroke="#a05d2a" stroke-width="8" stroke-linecap="round"/>
+</svg>

--- a/images/team-wiremu.svg
+++ b/images/team-wiremu.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 520 520">
+  <defs>
+    <linearGradient id="avatarBgWiremu" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1f201f"/>
+      <stop offset="100%" stop-color="#2e302e"/>
+    </linearGradient>
+    <linearGradient id="shirtWiremu" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#5f6f6b"/>
+      <stop offset="100%" stop-color="#3c4541"/>
+    </linearGradient>
+  </defs>
+  <circle cx="260" cy="260" r="250" fill="url(#avatarBgWiremu)"/>
+  <path d="M152 424c24-82 82-120 108-120h100c26 0 84 38 108 120 10 36-16 70-54 70H206c-38 0-66-34-54-70z" fill="url(#shirtWiremu)"/>
+  <circle cx="260" cy="192" r="118" fill="#8d5b32"/>
+  <path d="M192 186c-12 60 6 138 68 138s82-78 68-138c-10-46-36-78-68-78s-58 32-68 78z" fill="#b57640"/>
+  <path d="M176 150c18-52 58-80 84-80s64 28 82 80c10 26-8 50-30 40-24-12-42-20-52-20s-28 8-52 20c-22 10-40-14-32-40z" fill="#272927"/>
+  <circle cx="224" cy="238" r="20" fill="#202220"/>
+  <circle cx="300" cy="238" r="20" fill="#202220"/>
+  <circle cx="232" cy="232" r="8" fill="#f5f5f5" opacity="0.7"/>
+  <circle cx="308" cy="232" r="8" fill="#f5f5f5" opacity="0.7"/>
+  <path d="M228 286c18 16 46 16 64 0" fill="none" stroke="#8d5b32" stroke-width="8" stroke-linecap="round"/>
+  <path d="M206 322c4 24 26 42 54 42s50-18 54-42" fill="none" stroke="#202220" stroke-width="10" stroke-linecap="round"/>
+</svg>

--- a/index.html
+++ b/index.html
@@ -11,10 +11,10 @@
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
-<div class="container-fluid pl-0 pr-0 bg-img clearfix parallax-window2" data-parallax="scroll" data-image-src="images/banner.jpg">
+<div class="container-fluid pl-0 pr-0 bg-img clearfix parallax-window2" data-parallax="scroll" data-image-src="images/hero-balance.svg">
   <nav class="navbar navbar-expand-md navbar-dark">
-    <div class="container"> 
-      <a class="navbar-brand mr-auto"><img src="images/logo.png" alt="Body Rehab Physiotherapy Limited" /></a> 
+    <div class="container">
+      <a class="navbar-brand mr-auto"><img src="images/logo.png" alt="Body Rehab Physiotherapy Limited" /></a>
       <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#collapsibleNavbar"> 
         <span class="navbar-toggler-icon"></span> 
       </button>
@@ -30,7 +30,9 @@
   <div class="container">
     <div class="fh5co-banner-text-box">
       <div class="quote-box pl-10 pr-10">
-        <h2> BODY REHAB <br><span>PHYSIOTHERAPY LIMITED</span> </h2>
+        <h2> BODY REHAB <br><span>PHYSIOTHERAPY FOR EVERYDAY LIFE</span> </h2>
+        <p class="banner-lead">From tradies to new parents, weekend athletes to kaumātua, we tailor hands-on treatment and smart exercise programmes that help you move with confidence.</p>
+        <a class="btn btn-outline-light" href="#contact">Book a consultation</a>
       </div>
     </div>
   </div>
@@ -40,16 +42,16 @@
   <div class="container">
     <div class="row">
       <div class="col-md-6">
-        <h4>FOR PATIENTS</h4>
+        <h4>FOR EVERYDAY LIFE</h4>
         <h2>OUR SERVICES</h2>
         <hr />
-        <h5>PHYSIOTHERAPY SOLUTIONS</h5>
+        <h5>PHYSIOTHERAPY &amp; WELLNESS SUPPORT</h5>
         <p>
-          Personalized physiotherapy treatments • Injury rehabilitation • Post-surgery recovery • Pain management • Corrective exercises for musculoskeletal issues • Improving mobility and flexibility • Helping you regain strength safely and effectively.
+          Evidence-based physiotherapy with friendly guidance for people of all ages. We blend manual therapy, strengthening plans, workplace and sports rehab, gentle sessions for kaumātua, and restorative massage or mirimiri when requested.
         </p>
       </div>
       <div class="col-md-6">
-        <figure><img src="images/about.jpg" alt="physiotherapy" class="img-fluid" /></figure>
+        <figure><img src="images/massage-support.svg" alt="Brown hands providing a supportive shoulder massage in a clinic" class="img-fluid" /></figure>
       </div>
     </div>
   </div>
@@ -61,7 +63,7 @@
       <h2>ABOUT US</h2>
       <hr/>
       <p>
-        At Body Rehab Physiotherapy Limited, our team of experienced physiotherapists help patients recover from injuries, improve mobility, and manage pain effectively. We combine evidence-based treatments with personalized care to restore your body to its best possible condition.
+        At Body Rehab Physiotherapy Limited, our experienced team works with busy families, tradies, office workers, and elders to restore comfortable movement. We combine proven physiotherapy techniques with warm, people-first care so every person feels supported in their daily routine.
       </p>
     </div>
   </div>
@@ -76,21 +78,20 @@
         </div>
       </div>
       <div class="col-md-6 pr-5 pl-5">
-        <div class="card text-center"> 
-          <img class="card-img-top rounded-circle img-fluid" src="images/therapist1.jpg" alt="Therapist 1">
+        <div class="card text-center">
+          <img class="card-img-top rounded-circle img-fluid" src="images/team-emma.svg" alt="Emma Taylor, practice manager">
           <div class="card-body mb-5">
-            <h4 class="card-title">JANE DOE</h4>
-            <p class="card-text">Administration and patient support, managing appointments, ACC claims, and ensuring smooth communication between patients and the team.</p>
+            <h4 class="card-title">EMMA TAYLOR</h4>
+            <p class="card-text">Practice manager who keeps bookings on track, supports ACC paperwork, and makes sure every visitor is welcomed and heard.</p>
           </div>
         </div>
       </div>
       <div class="col-md-6 pl-5 pr-5">
-        <div class="card text-center"> 
-          <img class="card-img-top rounded-circle img-fluid" src="images/therapist2.jpg" alt="Therapist 2">
+        <div class="card text-center">
+          <img class="card-img-top rounded-circle img-fluid" src="images/team-wiremu.svg" alt="Wiremu Tai, lead physiotherapist">
           <div class="card-body mb-5">
-            <h4 class="card-title">JOHN SMITH</h4>
-            <p class="card-text">Physiotherapist specialising in recovery planning, exercise therapy, and tailored treatment programs to support patients in restoring strength and mobility.	
-</p>
+            <h4 class="card-title">WIREMU TAI</h4>
+            <p class="card-text">Lead physiotherapist blending hands-on therapy, exercise coaching, and mirimiri-informed care to keep everyone moving well.</p>
           </div>
         </div>
       </div>
@@ -100,27 +101,27 @@
         <div class="card">
           <div class="card-body mb-4">
             <h4 class="card-title">REHABILITATION</h4>
-            <p class="card-text">Comprehensive programs tailored to your specific injury and recovery goals.</p>
+            <p class="card-text">Personalised programmes that rebuild strength and confidence after injury or surgery.</p>
           </div>
-          <img class="card-img-top img-fluid" src="images/gallery1.jpg" alt="rehab session"> 
+          <img class="card-img-top img-fluid" src="images/gallery-recovery.svg" alt="Physiotherapist guiding a patient through rehabilitation exercises">
         </div>
       </div>
       <div class="col-md-4">
-        <div class="card"> 
-          <img class="card-img-top img-fluid" src="images/gallery2.jpg" alt="therapy session">
+        <div class="card">
+          <img class="card-img-top img-fluid" src="images/gallery-massage.svg" alt="Hands-on massage therapy session">
           <div class="card-body mt-4">
-            <h4 class="card-title">THERAPY SESSIONS</h4>
-            <p class="card-text">Guided treatment sessions with expert physiotherapists to restore strength and mobility.</p>
+            <h4 class="card-title">MASSAGE &amp; MIRIMIRI</h4>
+            <p class="card-text">Relaxing soft-tissue work and culturally informed mirimiri to settle busy muscles.</p>
           </div>
         </div>
       </div>
       <div class="col-md-4">
         <div class="card">
           <div class="card-body mb-4">
-            <h4 class="card-title">PAIN MANAGEMENT</h4>
-            <p class="card-text">Effective strategies and exercises to reduce discomfort and improve quality of life.</p>
+            <h4 class="card-title">ACTIVE LIFESTYLE</h4>
+            <p class="card-text">Everyday movement plans for families, runners, and weekend adventurers alike.</p>
           </div>
-          <img class="card-img-top img-fluid" src="images/gallery3.jpg" alt="pain management session"> 
+          <img class="card-img-top img-fluid" src="images/gallery-whanau.svg" alt="Family walking outdoors together">
         </div>
       </div>
     </div>
@@ -133,7 +134,7 @@
       <div class="col-md-3 footer1 d-flex">
         <div class="d-flex flex-wrap align-content-center"> 
           <a href="#"><img src="images/logo.png" alt="Body Rehab Physiotherapy Limited" /></a>
-          <p>Providing expert physiotherapy services for rehabilitation, recovery, and improved mobility.</p>
+          <p>Providing expert physiotherapy for rehabilitation, mobility, and everyday wellness across our community.</p>
           <p>&copy; 2025 Body Rehab Physiotherapy Limited. All rights reserved.</p>
         </div>
       </div>
@@ -165,9 +166,9 @@
         <h5>EMAIL</h5>
         <p>info@bodyrehab.co.nz</p>
         <div class="social-links">
-          <ul class="nav nav-item">
-            <li><a href="#" class="btn btn-secondary mr-1 mb-2"><img src="images/facebook.png" alt="facebook" /></a></li>
-            <li><a href="#" class="btn btn-secondary mr-1 ml-1 mb-2"><img src="images/facebook.png" alt="facebook" /></a></li>
+          <ul class="nav">
+            <li class="nav-item"><a href="#" class="nav-link p-0"><img src="images/icon-facebook.svg" alt="Facebook" /></a></li>
+            <li class="nav-item"><a href="#" class="nav-link p-0"><img src="images/icon-instagram.svg" alt="Instagram" /></a></li>
           </ul>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- realign the global styling with the original charcoal and gold palette while keeping the refreshed hero messaging legible
- add new illustrated hero, team, and gallery assets plus an ambient team backdrop to replace the reintroduced stock photos
- clean up the footer by introducing unique facebook and instagram icons styled to the brand treatment

## Testing
- python3 -m http.server 8000 (visual verification)


------
https://chatgpt.com/codex/tasks/task_e_68e4aaa9431c83329d39ceb2c7565a06