### PR TITLE
Refine hero layout and localize imagery assets

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -21,9 +21,14 @@ body {
   background-repeat: no-repeat;
   background-position: center;
   background-size: cover;
-  padding-bottom: 100px;
+  padding: 40px 0 80px 0;
   position: relative;
   overflow: hidden;
+}
+
+.bg-img .container {
+  display: flex;
+  justify-content: center;
 }
 
 .parallax-window2 {
@@ -83,20 +88,24 @@ a, a:hover {
 /* ---------------- Banner ---------------- */
 .fh5co-banner-text-box {
   position: relative;
-  display: inline-block;
-  margin: 220px auto 80px auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin: 140px auto 120px auto;
   padding: 36px 44px;
   background: rgba(32, 34, 32, 0.78);
   border-radius: 14px;
   max-width: 720px;
   text-align: center;
   box-shadow: 0 22px 60px rgba(12, 12, 12, 0.55);
-  animation: hero-float 9s ease-in-out infinite;
+  animation: hero-float 1.6s ease-out 1;
+  animation-fill-mode: forwards;
 }
 
 .fh5co-banner-text-box .quote-box {
   max-width: 100%;
   padding: 10px 0;
+  margin: 0 auto;
 }
 
 .fh5co-banner-text-box .quote-box h2 {
@@ -266,7 +275,7 @@ hr {
   position: relative;
   padding: 60px 0;
   margin: 80px 0 60px 0;
-  background: #1f201f url("../images/team-community.svg") center/cover no-repeat;
+  background: #1f201f url("../images/clinic-treatment.jpg") center/cover no-repeat;
   border-radius: 28px;
   overflow: hidden;
 }
@@ -387,7 +396,7 @@ footer .btn:hover {
 @media (max-width: 991px) {
   .fh5co-banner-text-box {
     padding: 28px 30px;
-    margin-top: 140px;
+    margin-top: 100px;
   }
   .fh5co-banner-text-box h2 {
     font-size: 36px;
@@ -404,7 +413,7 @@ footer .btn:hover {
 @media (max-width: 767px) {
   .fh5co-banner-text-box {
     padding: 22px 20px;
-    margin-top: 110px;
+    margin-top: 80px;
   }
   .fh5co-banner-text-box h2 {
     font-size: 28px;

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
-<div class="container-fluid pl-0 pr-0 bg-img clearfix parallax-window2" data-parallax="scroll" data-image-src="images/hero-banner.jpg" style="background-image: url('images/hero-banner.jpg');">
+<div class="container-fluid pl-0 pr-0 bg-img clearfix parallax-window2" style="background-image: url('images/therapist-session.jpg');">
   <nav class="navbar navbar-expand-md navbar-dark">
     <div class="container">
       <a class="navbar-brand mr-auto"><img src="images/logo.png" alt="Body Rehab Physiotherapy Limited" /></a>
@@ -51,13 +51,13 @@
         </p>
       </div>
       <div class="col-md-6">
-        <figure><img src="https://images.unsplash.com/photo-1526256262350-7da7584cf5eb?auto=format&fit=crop&w=1200&q=80" alt="Physiotherapist supporting a patient with shoulder exercises" class="img-fluid" loading="lazy" /></figure>
+        <figure><img src="images/our-services.jpg" alt="Physiotherapist supporting a patient with shoulder exercises" class="img-fluid" loading="lazy" /></figure>
       </div>
     </div>
   </div>
 </div>
 
-<div id="about-us" class="container-fluid fh5co-about-us pl-0 pr-0 parallax-window" data-parallax="scroll" data-image-src="images/about-us-bg.png">
+<div id="about-us" class="container-fluid fh5co-about-us pl-0 pr-0" style="background-image: url('images/about-us-bg.png');">
   <div class="container">
     <div class="col-sm-6 offset-sm-6">
       <h2>ABOUT US</h2>
@@ -81,7 +81,7 @@
       </div>
       <div class="col-md-6 pr-5 pl-5">
         <div class="card text-center">
-          <img class="card-img-top rounded-circle img-fluid" src="https://images.unsplash.com/photo-1607746882042-944635dfe10e?auto=format&fit=crop&w=600&q=80" alt="Portrait of physiotherapy coordinator Jane Doe" loading="lazy">
+          <img class="card-img-top rounded-circle img-fluid" src="images/therapist1.jpg" alt="Portrait of physiotherapy coordinator Jane Doe" loading="lazy">
           <div class="card-body mb-5">
             <h4 class="card-title">JANE DOE</h4>
             <p class="card-text">Administration and patient support, managing appointments, ACC claims, and ensuring smooth communication between patients and the team.</p>
@@ -90,7 +90,7 @@
       </div>
       <div class="col-md-6 pl-5 pr-5">
         <div class="card text-center">
-          <img class="card-img-top rounded-circle img-fluid" src="https://images.unsplash.com/photo-1525351484163-7529414344d8?auto=format&fit=crop&w=600&q=80" alt="Portrait of lead physiotherapist John Smith" loading="lazy">
+          <img class="card-img-top rounded-circle img-fluid" src="images/therapist2.jpg" alt="Portrait of lead physiotherapist John Smith" loading="lazy">
           <div class="card-body mb-5">
             <h4 class="card-title">JOHN SMITH</h4>
             <p class="card-text">Physiotherapist specialising in recovery planning, exercise therapy, and tailored treatment programs to support patients in restoring strength and mobility.</p>
@@ -105,12 +105,12 @@
             <h4 class="card-title">REHABILITATION</h4>
             <p class="card-text">Comprehensive programs tailored to your specific injury and recovery goals.</p>
           </div>
-          <img class="card-img-top img-fluid" src="https://images.unsplash.com/photo-1573496529574-be85d6a60704?auto=format&fit=crop&w=1200&q=80" alt="Physiotherapist supporting a client during rehabilitation exercises" loading="lazy">
+          <img class="card-img-top img-fluid" src="images/gallery1.jpg" alt="Physiotherapist supporting a client during rehabilitation exercises" loading="lazy">
         </div>
       </div>
       <div class="col-md-4">
         <div class="card">
-          <img class="card-img-top img-fluid" src="https://images.unsplash.com/photo-1580281658629-84d95303f5a7?auto=format&fit=crop&w=1200&q=80" alt="Massage therapist providing hands-on treatment" loading="lazy">
+          <img class="card-img-top img-fluid" src="images/gallery2.jpg" alt="Massage therapist providing hands-on treatment" loading="lazy">
           <div class="card-body mt-4">
             <h4 class="card-title">MASSAGE &amp; MIRIMIRI</h4>
             <p class="card-text">Relaxing soft-tissue work and culturally informed mirimiri to settle busy muscles.</p>
@@ -123,7 +123,7 @@
             <h4 class="card-title">ACTIVE LIFESTYLE</h4>
             <p class="card-text">Everyday movement plans for families, runners, and weekend adventurers alike.</p>
           </div>
-          <img class="card-img-top img-fluid" src="https://images.unsplash.com/photo-1506086679524-493c64fdfaa6?auto=format&fit=crop&w=1200&q=80" alt="Family walking outdoors together" loading="lazy">
+          <img class="card-img-top img-fluid" src="images/gallery3.jpg" alt="Family walking outdoors together" loading="lazy">
         </div>
       </div>
     </div>
@@ -180,6 +180,5 @@
 
 <script src="js/jquery.min.js"></script>
 <script src="js/bootstrap.min.js"></script>
-<script src="js/parallax.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- tune the hero banner spacing, center alignment, and animation so the quote card sits prominently without constant motion
- replace remote service, team, and gallery images with local assets and swap the team section backdrop for an in-clinic photo
- disable the parallax script hook to prevent scroll-based movement while keeping section styling intact

## Testing
- python -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68e4c3ec48f48332a603dfb34617c318