### PR TITLE
Restore hero parallax and refine header styling

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -21,7 +21,7 @@ body {
   background-repeat: no-repeat;
   background-position: center;
   background-size: cover;
-  padding: 40px 0 80px 0;
+  padding: 0 0 80px 0;
   position: relative;
   overflow: hidden;
 }
@@ -39,8 +39,9 @@ body {
   content: "";
   position: absolute;
   inset: 0;
-  background: linear-gradient(135deg, rgba(32, 34, 32, 0.85), rgba(42, 44, 42, 0.7)),
-              radial-gradient(circle at 20% 20%, rgba(255, 209, 102, 0.18), transparent 60%);
+  background:
+    linear-gradient(180deg, rgba(32, 34, 32, 0.98) 0%, rgba(32, 34, 32, 0.92) 140px, rgba(42, 44, 42, 0.7) 100%),
+    radial-gradient(circle at 20% 20%, rgba(255, 209, 102, 0.18), transparent 60%);
   z-index: 0;
 }
 
@@ -51,7 +52,28 @@ body {
 
 /* ---------------- Navbar ---------------- */
 nav {
-  background: rgba(32, 34, 32, 0.95);
+  background: linear-gradient(90deg, rgba(32, 34, 32, 0.98), rgba(42, 44, 42, 0.92));
+  border-bottom: 1px solid rgba(255, 209, 102, 0.18);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.4);
+  padding: 18px 0;
+  position: relative;
+  z-index: 2;
+}
+
+.navbar-brand {
+  display: flex;
+  align-items: center;
+  padding: 6px 18px;
+  margin-right: 30px;
+  border-radius: 18px;
+  background: linear-gradient(135deg, rgba(40, 42, 40, 0.95), rgba(28, 29, 28, 0.95));
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.45);
+}
+
+.navbar-brand img {
+  display: block;
+  max-height: 64px;
+  width: auto;
 }
 
 .navbar-nav a {
@@ -59,6 +81,14 @@ nav {
   text-transform: uppercase;
   color: #F5E6B8;
   font-weight: 600;
+}
+
+.navbar .navbar-toggler {
+  border-color: rgba(255, 209, 102, 0.45);
+}
+
+.navbar .navbar-toggler:focus {
+  box-shadow: 0 0 0 0.1rem rgba(255, 209, 102, 0.45);
 }
 
 .navbar-nav a:hover {
@@ -91,15 +121,13 @@ a, a:hover {
   display: flex;
   flex-direction: column;
   align-items: center;
-  margin: 140px auto 120px auto;
+  margin: 120px auto 120px auto;
   padding: 36px 44px;
   background: rgba(32, 34, 32, 0.78);
   border-radius: 14px;
   max-width: 720px;
   text-align: center;
   box-shadow: 0 22px 60px rgba(12, 12, 12, 0.55);
-  animation: hero-float 1.6s ease-out 1;
-  animation-fill-mode: forwards;
 }
 
 .fh5co-banner-text-box .quote-box {
@@ -394,6 +422,13 @@ footer .btn:hover {
 
 /* ---------------- Media Queries ---------------- */
 @media (max-width: 991px) {
+  nav {
+    padding: 16px 0;
+  }
+  .navbar-brand {
+    margin-right: 15px;
+    padding: 6px 14px;
+  }
   .fh5co-banner-text-box {
     padding: 28px 30px;
     margin-top: 100px;
@@ -411,6 +446,10 @@ footer .btn:hover {
 }
 
 @media (max-width: 767px) {
+  .navbar-brand {
+    margin-right: 0;
+    margin-bottom: 10px;
+  }
   .fh5co-banner-text-box {
     padding: 22px 20px;
     margin-top: 80px;

--- a/index.html
+++ b/index.html
@@ -11,10 +11,10 @@
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
-<div class="container-fluid pl-0 pr-0 bg-img clearfix parallax-window2" style="background-image: url('images/therapist-session.jpg');">
+<div id="top" class="container-fluid pl-0 pr-0 bg-img clearfix parallax-window2" data-parallax="scroll" data-image-src="images/therapist-session.jpg" style="background-image: url('images/therapist-session.jpg');">
   <nav class="navbar navbar-expand-md navbar-dark">
     <div class="container">
-      <a class="navbar-brand mr-auto"><img src="images/logo.png" alt="Body Rehab Physiotherapy Limited" /></a>
+      <a class="navbar-brand mr-auto" href="#top"><img src="images/logo.png" alt="Body Rehab Physiotherapy Limited" /></a>
       <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#collapsibleNavbar"> 
         <span class="navbar-toggler-icon"></span> 
       </button>
@@ -180,5 +180,7 @@
 
 <script src="js/jquery.min.js"></script>
 <script src="js/bootstrap.min.js"></script>
+<script src="js/parallax.js"></script>
+<script src="js/main.js"></script>
 </body>
 </html>

--- a/js/main.js
+++ b/js/main.js
@@ -1,29 +1,36 @@
-// ;(function () {
+;(function ($) {
+  'use strict';
 
-    // 'use strict';
+  function extractImageFromStyle($el) {
+    var background = $el.css('background-image');
+    if (!background || background === 'none') {
+      return null;
+    }
 
-    // var wowAnimation = function() {
-        // var wow = new WOW(
-            // {
-                // animateClass: 'animated',
-                // offset:       150,
-                // callback:     function(box) {
-                    // console.log("WOW: animating <" + box.tagName.toLowerCase() + ">")
-                // }
-            // }
-        // );
-        // wow.init();
-    // }
+    var matches = background.match(/url\((['"]?)(.*?)\1\)/);
+    return matches && matches[2] ? matches[2] : null;
+  }
 
+  function initParallax() {
+    if (typeof $.fn.parallax !== 'function') {
+      return;
+    }
 
-    // (function($) {
-        // wowAnimation();
-    // })(jQuery);
+    $('.parallax-window2').each(function () {
+      var $window = $(this);
+      var imageSrc = $window.data('image-src') || extractImageFromStyle($window);
 
+      if (!imageSrc) {
+        return;
+      }
 
-// }());
+      $window.parallax({
+        imageSrc: imageSrc
+      });
+    });
+  }
 
-
-
-// main.js
-// Currently, no animations are used. Keeping this file for future scripts if needed.
+  $(function () {
+    initParallax();
+  });
+})(jQuery);


### PR DESCRIPTION
## Summary
- reintroduce the parallax hero banner by wiring in the plugin and a lightweight initializer while keeping the quote box static
- restyle the header background, navigation, and logo treatment to appear as a cohesive block without the hero image peeking through on desktop
- tweak responsive spacing and toggler styling so the updated header layout scales cleanly on smaller screens

## Testing
- Manual smoke test in browser

------
https://chatgpt.com/codex/tasks/task_e_68e4c6a1f0908332bea263bcfdfeffac