### PR TITLE
Restore parallax backgrounds and adjust header logo

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -68,17 +68,25 @@ nav {
 .navbar-brand {
   display: flex;
   align-items: center;
-  padding: 6px 18px;
   margin-right: 30px;
-  border-radius: 18px;
-  background: linear-gradient(135deg, rgba(40, 42, 40, 0.95), rgba(28, 29, 28, 0.95));
-  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.45);
+  padding: 0;
+  background: none;
+  border-radius: 0;
+  box-shadow: none;
 }
 
 .navbar-brand img {
   display: block;
-  max-height: 64px;
+  height: 72px;
+  max-height: 72px;
   width: auto;
+}
+
+@media (max-width: 576px) {
+  .navbar-brand img {
+    height: 56px;
+    max-height: 56px;
+  }
 }
 
 .navbar-nav a {

--- a/index.html
+++ b/index.html
@@ -57,7 +57,7 @@
   </div>
 </div>
 
-<div id="about-us" class="container-fluid fh5co-about-us pl-0 pr-0" style="background-image: url('images/about-us-bg.png');">
+<div id="about-us" class="container-fluid fh5co-about-us pl-0 pr-0 bg-img parallax-window parallax-window2" data-parallax="scroll" data-image-src="images/about-us-bg.png" style="background-image: url('images/about-us-bg.png');">
   <div class="container">
     <div class="col-sm-6 offset-sm-6">
       <h2>ABOUT US</h2>


### PR DESCRIPTION
## Summary
- reinstate the parallax plugin on the About Us background using the existing parallax utility classes
- simplify the navbar brand styling so the logo is no longer wrapped in a pill button and can fill the header height
- add responsive handling for the logo height on smaller screens

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e4caf1a7c88332948d23c185696065