### PR TITLE
Adjust team heading typography and mobile spacing

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -253,7 +253,7 @@ hr {
   letter-spacing: 3px;
   margin-bottom: 12px;
   text-transform: uppercase;
-  font-size: 16px;
+  font-size: 24px;
 }
 
 .fh5co-content-box .section-heading h2 {
@@ -479,6 +479,10 @@ footer .btn:hover {
   .banner-lead {
     font-size: 15px;
     margin: 16px auto 24px auto;
+  }
+  .fh5co-content-box .trainers .card,
+  .fh5co-content-box .gallery .card {
+    margin-bottom: 30px;
   }
   .fh5co-content-box .gallery .card-img-top {
     height: 200px;


### PR DESCRIPTION
## Summary
- match the "MEET THE TEAM" subheading size with the services section for consistent typography
- add vertical spacing to team and gallery cards on mobile to prevent stacked content from crowding

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4d0ac5d3483328316b346ad5bfa56