### PR TITLE
Restore original parallax behaviour on mobile

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -26,11 +26,6 @@ body {
   overflow: hidden;
 }
 
-.parallax-window {
-  background-attachment: fixed;
-  will-change: background-position;
-}
-
 .bg-img .container {
   display: flex;
   justify-content: center;
@@ -459,9 +454,6 @@ footer .btn:hover {
 }
 
 @media (max-width: 767px) {
-  .parallax-window {
-    background-attachment: scroll;
-  }
   .navbar-brand {
     margin-right: 0;
     margin-bottom: 10px;

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
-<div id="top" class="container-fluid pl-0 pr-0 bg-img clearfix parallax-window parallax-window2" data-parallax="scroll" data-image-src="images/therapist-session.jpg" style="background-image: url('images/therapist-session.jpg');">
+<div id="top" class="container-fluid pl-0 pr-0 bg-img clearfix parallax-window2" data-parallax="scroll" data-image-src="images/therapist-session.jpg">
   <nav class="navbar navbar-expand-md navbar-dark">
     <div class="container">
       <a class="navbar-brand mr-auto" href="#top"><img src="images/logo.png" alt="Body Rehab Physiotherapy Limited" /></a>
@@ -57,7 +57,7 @@
   </div>
 </div>
 
-<div id="about-us" class="container-fluid fh5co-about-us pl-0 pr-0 bg-img parallax-window parallax-window2" data-parallax="scroll" data-image-src="images/about-us-bg.png" style="background-image: url('images/about-us-bg.png');">
+<div id="about-us" class="container-fluid fh5co-about-us pl-0 pr-0 bg-img parallax-window" data-parallax="scroll" data-image-src="images/about-us-bg.png">
   <div class="container">
     <div class="col-sm-6 offset-sm-6">
       <h2>ABOUT US</h2>

--- a/js/main.js
+++ b/js/main.js
@@ -1,36 +1,4 @@
 ;(function ($) {
   'use strict';
-
-  function extractImageFromStyle($el) {
-    var background = $el.css('background-image');
-    if (!background || background === 'none') {
-      return null;
-    }
-
-    var matches = background.match(/url\((['"]?)(.*?)\1\)/);
-    return matches && matches[2] ? matches[2] : null;
-  }
-
-  function initParallax() {
-    if (typeof $.fn.parallax !== 'function') {
-      return;
-    }
-
-    $('.parallax-window2').each(function () {
-      var $window = $(this);
-      var imageSrc = $window.data('image-src') || extractImageFromStyle($window);
-
-      if (!imageSrc) {
-        return;
-      }
-
-      $window.parallax({
-        imageSrc: imageSrc
-      });
-    });
-  }
-
-  $(function () {
-    initParallax();
-  });
+  // Parallax behavior is handled by the data attributes consumed by parallax.js.
 })(jQuery);


### PR DESCRIPTION
## Summary
- remove the custom parallax initialisation and CSS overrides so the original plugin handles the background images again
- revert the parallax sections to rely on their data attributes instead of inline background overrides

## Testing
- Manual verification in a mobile viewport

------
https://chatgpt.com/codex/tasks/task_e_68e4d4663c448332873a86aede88d781