### PR TITLE
Restyle mobile navigation menu and switch to Roboto font

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3,12 +3,9 @@ Theme Name: Body Rehab Physiotherapy Limited
 Based on Fox template
 */
 
-/* Import Google Font */
-@import url('https://fonts.googleapis.com/css2?family=Lato:wght@300;400;700&display=swap');
-
 /* ---------------- Body ---------------- */
 body {
-  font-family: 'Lato', sans-serif;
+  font-family: 'Roboto', sans-serif;
   overflow-x: hidden;
   background-color: #202220;
   color: #F1F1F1;
@@ -63,6 +60,11 @@ nav {
   padding: 18px 0;
   position: relative;
   z-index: 2;
+}
+
+.navbar-collapse {
+  justify-content: flex-end;
+  transition: transform 0.3s ease, opacity 0.3s ease;
 }
 
 .navbar-brand {
@@ -120,6 +122,76 @@ nav {
   background: #FFD166;
   border-color: #FFD166;
   color: #202220;
+}
+
+@media (max-width: 767.98px) {
+  .navbar .navbar-collapse {
+    position: absolute;
+    top: 100%;
+    right: 12px;
+    width: 220px;
+    background: rgba(32, 34, 32, 0.96);
+    border: 1px solid rgba(255, 209, 102, 0.2);
+    border-radius: 14px;
+    padding: 18px 16px;
+    box-shadow: 0 18px 40px rgba(0, 0, 0, 0.45);
+    transform: translateY(-12px);
+    opacity: 0;
+    pointer-events: none;
+  }
+
+  .navbar .navbar-collapse.show {
+    transform: translateY(0);
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  .navbar .navbar-collapse.collapsing {
+    height: auto !important;
+    transition: transform 0.3s ease, opacity 0.3s ease;
+    display: block;
+    pointer-events: auto;
+  }
+
+  .navbar .navbar-nav {
+    flex-direction: column;
+    align-items: flex-end;
+    width: 100%;
+    gap: 12px;
+  }
+
+  .navbar .nav-item {
+    width: 100%;
+  }
+
+  .navbar .nav-link {
+    display: block;
+    width: 100%;
+    padding: 12px 18px;
+    text-align: right;
+    background: linear-gradient(135deg, rgba(255, 209, 102, 0.18), rgba(245, 230, 184, 0.08));
+    border-radius: 12px;
+    color: #F5E6B8;
+    font-weight: 600;
+    position: relative;
+    box-shadow: inset 0 0 0 1px rgba(255, 209, 102, 0.18), 0 10px 22px rgba(0, 0, 0, 0.25);
+  }
+
+  .navbar .nav-link::before {
+    content: "";
+    position: absolute;
+    top: -16px;
+    right: 22px;
+    width: 2px;
+    height: 14px;
+    background: rgba(255, 209, 102, 0.45);
+    border-radius: 2px;
+  }
+
+  .navbar .nav-link:hover {
+    background: linear-gradient(135deg, rgba(255, 209, 102, 0.3), rgba(245, 230, 184, 0.18));
+    color: #FFD166;
+  }
 }
 
 /* ---------------- Links ---------------- */

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
 
   <!-- Bootstrap CSS -->
   <link rel="stylesheet" href="css/bootstrap.min.css" type="text/css">
-  <link href="https://fonts.googleapis.com/css?family=Lato:300,400,700" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>


### PR DESCRIPTION
## Summary
- switch the site typography to the Roboto family from Google Fonts
- restyle the collapsed navbar so the mobile menu drops as right-aligned hanging buttons

## Testing
- Not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e4d54289dc8332b61c835076b8fd7e