### PR TITLE
Restore hero banner image and improve navigation links

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -30,6 +30,10 @@ body {
 
 .parallax-window2 {
   background-color: #202220;
+  background-image: url('../images/therapist-session.jpg');
+  background-position: center;
+  background-size: cover;
+  overflow: visible;
 }
 
 .parallax-window2::before {
@@ -133,6 +137,7 @@ nav {
     transform: translateY(-12px);
     opacity: 0;
     pointer-events: none;
+    z-index: 5;
   }
 
   .navbar .navbar-collapse.show {

--- a/index.html
+++ b/index.html
@@ -135,7 +135,7 @@
     <div class="row">
       <div class="col-md-3 footer1 d-flex">
         <div class="d-flex flex-wrap align-content-center"> 
-          <a href="#"><img src="images/logo.png" alt="Body Rehab Physiotherapy Limited" /></a>
+          <a href="#top"><img src="images/logo.png" alt="Body Rehab Physiotherapy Limited" /></a>
           <p>Providing expert physiotherapy for rehabilitation, mobility, and everyday wellness across our community.</p>
           <p>&copy; 2025 Body Rehab Physiotherapy Limited. All rights reserved.</p>
         </div>

--- a/js/main.js
+++ b/js/main.js
@@ -1,4 +1,25 @@
 ;(function ($) {
   'use strict';
-  // Parallax behavior is handled by the data attributes consumed by parallax.js.
+
+  // Enable smooth scrolling for in-page navigation buttons and links.
+  $(document).on('click', 'a[href^="#"]', function (event) {
+    var anchor = $(this).attr('href');
+
+    if (!anchor || anchor.length < 2) {
+      return;
+    }
+
+    var $target = $(anchor);
+
+    if ($target.length) {
+      event.preventDefault();
+
+      $('html, body').animate({
+        scrollTop: $target.offset().top - 72
+      }, 600);
+
+      // Close the mobile navigation after selecting a link.
+      $('.navbar-collapse.show').collapse('hide');
+    }
+  });
 })(jQuery);


### PR DESCRIPTION
## Summary
- restore the hero banner background so the parallax header always displays the therapist image
- allow the mobile navigation menu to appear above the banner content and keep footer logo linking back to the top
- add smooth scrolling for in-page buttons and collapse the mobile menu after selection

## Testing
- Visual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68e4d6fcde0c83328821452066876924