### PR TITLE
Stretch services background graphic

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -271,11 +271,22 @@ a, a:hover {
 /* ---------------- Sections ---------------- */
 .fh5co-network,
 .fh5co-about-us {
+  padding: 70px 0 50px 0;
+  position: relative;
+}
+
+.fh5co-network {
+  background-color: #25231f;
+  background-image: url('../images/tukutuku-sophisticated.svg');
+  background-position: center top;
+  background-repeat: no-repeat;
+  background-size: cover;
+}
+
+.fh5co-about-us {
   background-repeat: no-repeat;
   background-position: center;
   background-size: cover;
-  padding: 70px 0 50px 0;
-  position: relative;
 }
 
 .fh5co-network::before,
@@ -284,8 +295,22 @@ a, a:hover {
   position: absolute;
   top: 0; left: 0;
   width: 100%; height: 100%;
-  background: rgba(32, 34, 32, 0.7);
   z-index: 1;
+}
+
+.fh5co-network::before {
+  background:
+    linear-gradient(180deg, rgba(28, 26, 22, 0.7) 0%, rgba(28, 26, 22, 0.55) 52%, rgba(28, 26, 22, 0.72) 100%),
+    radial-gradient(circle at 16% 22%, rgba(255, 209, 102, 0.1), transparent 58%);
+}
+
+.fh5co-about-us::before {
+  background: rgba(32, 34, 32, 0.7);
+}
+
+.fh5co-network > .container {
+  position: relative;
+  z-index: 2;
 }
 
 .fh5co-network h2,

--- a/images/tukutuku-sophisticated.svg
+++ b/images/tukutuku-sophisticated.svg
@@ -1,0 +1,70 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewBox="0 0 256 256">
+  <defs>
+    <!-- Sandstone palette -->
+    <style>
+      .a { stroke:#C8B28A; stroke-opacity:.85; stroke-width:2; fill:none; stroke-linecap:round; stroke-linejoin:round; }
+      .b { stroke:#C8B28A; stroke-opacity:.55; stroke-width:1.4; fill:none; stroke-linecap:round; stroke-linejoin:round; }
+      .c { stroke:#C8B28A; stroke-opacity:.35; stroke-width:1; fill:none; stroke-linecap:round; stroke-linejoin:round; }
+      .d { stroke:#C8B28A; stroke-opacity:.25; stroke-width:.9; fill:none; stroke-linecap:round; stroke-linejoin:round; }
+    </style>
+
+    <!-- one half (top). We mirror it for the bottom to ensure symmetry -->
+    <g id="half">
+
+      <!-- 1) Double niho taniwha spine (primary zigzags) -->
+      <path class="a"
+        d="M0 72 L16 56 L32 72 L48 56 L64 72 L80 56 L96 72 L112 56 L128 72 L144 56 L160 72 L176 56 L192 72 L208 56 L224 72 L240 56 L256 72"/>
+      <path class="a"
+        d="M0 88 L16 72 L32 88 L48 72 L64 88 L80 72 L96 88 L112 72 L128 88 L144 72 L160 88 L176 72 L192 88 L208 72 L224 88 L240 72 L256 88"/>
+
+      <!-- 2) Secondary inner zigzags for depth -->
+      <path class="b"
+        d="M0 64 L16 48 L32 64 L48 48 L64 64 L80 48 L96 64 L112 48 L128 64 L144 48 L160 64 L176 48 L192 64 L208 48 L224 64 L240 48 L256 64"/>
+      <path class="b"
+        d="M0 96 L16 80 L32 96 L48 80 L64 96 L80 80 L96 96 L112 80 L128 96 L144 80 L160 96 L176 80 L192 96 L208 80 L224 96 L240 80 L256 96"/>
+
+      <!-- 3) Tukutuku "cross-lashing" stitches (small X forms along the diagonals) -->
+      <g class="c">
+        <!-- forward diagonals -->
+        <path d="M8 56 L16 64 M24 56 L32 64 M40 56 L48 64 M56 56 L64 64 M72 56 L80 64 M88 56 L96 64
+                 M104 56 L112 64 M120 56 L128 64 M136 56 L144 64 M152 56 L160 64 M168 56 L176 64
+                 M184 56 L192 64 M200 56 L208 64 M216 56 L224 64 M232 56 L240 64 M248 56 L256 64"/>
+        <!-- back diagonals -->
+        <path d="M16 56 L8 64 M32 56 L24 64 M48 56 L40 64 M64 56 L56 64 M80 56 L72 64 M96 56 L88 64
+                 M112 56 L104 64 M128 56 L120 64 M144 56 L136 64 M160 56 L152 64 M176 56 L168 64
+                 M192 56 L184 64 M208 56 L200 64 M224 56 L216 64 M240 56 L232 64 M256 56 L248 64"/>
+      </g>
+
+      <!-- 4) Poutama (step) bands for tukutuku feel -->
+      <g class="d">
+        <!-- upper step band -->
+        <path d="M0 40 H256"/>
+        <path d="M0 40 L8 32 L16 40 L24 32 L32 40 L40 32 L48 40 L56 32 L64 40 L72 32 L80 40 L88 32 L96 40
+                 L104 32 L112 40 L120 32 L128 40 L136 32 L144 40 L152 32 L160 40 L168 32 L176 40
+                 L184 32 L192 40 L200 32 L208 40 L216 32 L224 40 L232 32 L240 40 L248 32 L256 40"/>
+        <!-- subtle divider lines -->
+        <path d="M0 52 H256"/>
+        <path d="M0 100 H256"/>
+      </g>
+
+      <!-- 5) Fine chevron infill to add texture without heaviness -->
+      <g class="d">
+        <path d="M0 80 L8 72 L16 80 L24 72 L32 80 L40 72 L48 80 L56 72 L64 80 L72 72 L80 80 L88 72 L96 80
+                 L104 72 L112 80 L120 72 L128 80 L136 72 L144 80 L152 72 L160 80 L168 72 L176 80
+                 L184 72 L192 80 L200 72 L208 80 L216 72 L224 80 L232 72 L240 80 L248 72 L256 80"/>
+      </g>
+
+    </g>
+  </defs>
+
+  <!-- Top half -->
+  <use href="#half"/>
+
+  <!-- Bottom half mirrored around y = 128 (the middle of 256) -->
+  <g transform="translate(0,256) scale(1,-1)">
+    <use href="#half"/>
+  </g>
+
+  <!-- Invisible seam guards to ensure perfect tiling -->
+  <path d="M0 0 H256 M0 256 H256" stroke="rgba(0,0,0,0)" fill="none"/>
+</svg>


### PR DESCRIPTION
## Summary
- stretch the services section tukutuku background to cover the full section without repeating
- soften the overlay gradient so the sandstone motif reads true while remaining subtle

## Testing
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68e4e98d0d788332a1dbccd2656d9088