### PR TITLE
Rearrange services highlights around gallery

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -256,6 +256,15 @@ padding: 30px 0 350px 0;
   width: 100%;
 }
 
+.services-section--continued {
+  width: 100%;
+}
+
+.services-intro--continued {
+  padding: clamp(26px, 4vw, 48px);
+  border-top: 1px solid rgba(199, 193, 153, 0.24);
+}
+
 .services-heading {
   display: grid;
   gap: 8px;

--- a/index.html
+++ b/index.html
@@ -71,18 +71,6 @@
               <span class="service-highlight-title">Soft Tissue Treatment</span>
               <p class="service-highlight-copy">Targeted release techniques that ease tight, sore areas.</p>
             </li>
-            <li>
-              <span class="service-highlight-title">Acupuncture</span>
-              <p class="service-highlight-copy">Western medical acupuncture to reduce pain and support recovery.</p>
-            </li>
-            <li>
-              <span class="service-highlight-title">Hydrotherapy</span>
-              <p class="service-highlight-copy">Pool-based plans for low-impact strength and mobility gains.</p>
-            </li>
-            <li>
-              <span class="service-highlight-title">Diagnostic &amp; Specialist Referrals</span>
-              <p class="service-highlight-copy">Access to X-ray, ultrasound, and trusted experts when you need them.</p>
-            </li>
           </ul>
         </div>
       </div>
@@ -113,6 +101,26 @@
             <p class="card-text">Practical strategies and exercises that ease niggles and lift your day-to-day comfort.</p>
           </div>
           <img class="card-img-top img-fluid" src="images/service-electrotherapy.jpg" alt="Electrotherapy pads supporting muscle recovery">
+        </div>
+      </div>
+    </div>
+    <div class="row services-section services-section--continued mt-4 mt-lg-5">
+      <div class="col-lg-12">
+        <div class="services-intro services-intro--continued wow fadeInUp animate-soft" data-wow-duration="1.5s" data-wow-offset="70">
+          <ul class="list-unstyled service-highlight-list">
+            <li>
+              <span class="service-highlight-title">Acupuncture</span>
+              <p class="service-highlight-copy">Western medical acupuncture to reduce pain and support recovery.</p>
+            </li>
+            <li>
+              <span class="service-highlight-title">Hydrotherapy</span>
+              <p class="service-highlight-copy">Pool-based plans for low-impact strength and mobility gains.</p>
+            </li>
+            <li>
+              <span class="service-highlight-title">Diagnostic &amp; Specialist Referrals</span>
+              <p class="service-highlight-copy">Access to X-ray, ultrasound, and trusted experts when you need them.</p>
+            </li>
+          </ul>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- split the services highlight list so the first three items sit before the gallery and the rest follow it
- add styling for the continued services block to preserve spacing and visual separation

## Testing
- no automated tests were run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68f0f2956a948332b402ac949b08e9e5