### PR TITLE
Add cards for additional physiotherapy services

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,6 +115,60 @@
           <img class="card-img-top img-fluid" src="images/service-electrotherapy.jpg" alt="Electrotherapy pads supporting muscle recovery">
         </div>
       </div>
+      <div class="col-md-4">
+        <div class="card wow fadeInUp animate-soft" data-wow-duration="1.5s" data-wow-delay=".15s" data-wow-offset="70">
+          <div class="card-body">
+            <h4 class="card-title">MANUAL THERAPY</h4>
+            <p class="card-text">Hands-on care to restore joint and soft tissue function.</p>
+          </div>
+          <img class="card-img-top img-fluid" src="images/service-hands-on.jpg" alt="Physiotherapist delivering manual therapy">
+        </div>
+      </div>
+      <div class="col-md-4">
+        <div class="card wow fadeInUp animate-soft" data-wow-duration="1.5s" data-wow-delay=".25s" data-wow-offset="70">
+          <div class="card-body">
+            <h4 class="card-title">EXERCISE THERAPY</h4>
+            <p class="card-text">Guided movement programmes tailored to your goals.</p>
+          </div>
+          <img class="card-img-top img-fluid" src="images/service-injury-rehab.jpg" alt="Client completing guided exercise therapy">
+        </div>
+      </div>
+      <div class="col-md-4">
+        <div class="card wow fadeInUp animate-soft" data-wow-duration="1.5s" data-wow-delay=".35s" data-wow-offset="70">
+          <div class="card-body">
+            <h4 class="card-title">SOFT TISSUE TREATMENT</h4>
+            <p class="card-text">Targeted release techniques that ease tight, sore areas.</p>
+          </div>
+          <img class="card-img-top img-fluid" src="images/service-sports-taping.jpg" alt="Soft tissue therapy with sports taping support">
+        </div>
+      </div>
+      <div class="col-md-4">
+        <div class="card wow fadeInUp animate-soft" data-wow-duration="1.5s" data-wow-delay=".15s" data-wow-offset="70">
+          <div class="card-body">
+            <h4 class="card-title">ACUPUNCTURE</h4>
+            <p class="card-text">Western medical acupuncture to reduce pain and support recovery.</p>
+          </div>
+          <img class="card-img-top img-fluid" src="images/service-dry-needling.jpg" alt="Acupuncture needles applied during treatment">
+        </div>
+      </div>
+      <div class="col-md-4">
+        <div class="card wow fadeInUp animate-soft" data-wow-duration="1.5s" data-wow-delay=".25s" data-wow-offset="70">
+          <div class="card-body">
+            <h4 class="card-title">HYDROTHERAPY</h4>
+            <p class="card-text">Pool-based plans for low-impact strength and mobility gains.</p>
+          </div>
+          <img class="card-img-top img-fluid" src="images/gallery2.jpg" alt="Hydrotherapy exercises performed in a pool">
+        </div>
+      </div>
+      <div class="col-md-4">
+        <div class="card wow fadeInUp animate-soft" data-wow-duration="1.5s" data-wow-delay=".35s" data-wow-offset="70">
+          <div class="card-body">
+            <h4 class="card-title">DIAGNOSTIC &amp; SPECIALIST REFERRALS</h4>
+            <p class="card-text">Access to X-ray, ultrasound, and trusted experts when you need them.</p>
+          </div>
+          <img class="card-img-top img-fluid" src="images/gallery3.jpg" alt="Patient reviewing diagnostic results with a specialist">
+        </div>
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- add six new service cards to highlight manual therapy, exercise therapy, soft tissue treatment, acupuncture, hydrotherapy, and diagnostic referrals
- reuse existing gallery styling so the new offerings match the current rehabilitation, therapy sessions, and pain management tiles

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f0f475497083328ea2768765bf2d87